### PR TITLE
fixed adding column to the right bug

### DIFF
--- a/src/stores/dataStore.ts
+++ b/src/stores/dataStore.ts
@@ -72,9 +72,9 @@ export const useDataStore = defineStore('chartData', {
         addNewCol(selectedColIdx: string, right: boolean = true): void {
             const newCol = '';
             // determine new position based on insert right/left
-            const newIdx = right ? selectedColIdx + 1 : selectedColIdx;
+            const newIdx = right ? parseInt(selectedColIdx) + 1 : parseInt(selectedColIdx);
             // add new header and empty col of values
-            this.headers.splice(parseInt(newIdx), 0, newCol); 
+            this.headers.splice(newIdx, 0, newCol); 
             this.gridData.forEach((row) => {
                 row.splice(newIdx, 0, '');
             });


### PR DESCRIPTION
### Related Item(s)
Issue #50 

### Changes
- Insert column to the right button now correctly adds a column to the right instead of to the end

### Testing
Steps:
1. Select a column
2. Perform column action: Insert column right
