### PR TITLE
Fixed colour contrast for placeholder text on customize chart tab

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -6,6 +6,12 @@
     text-align: center;
 }
 
-.tippy-box[data-animation='chapter-menu'][data-placement^=right] > .tippy-backdrop {
+.tippy-box[data-animation='chapter-menu'][data-placement^=right]>.tippy-backdrop {
     transform-origin: 50% 0 !important;
+}
+
+@layer base {
+    input[type='text'] {
+        @apply placeholder-gray-600;
+    }
 }


### PR DESCRIPTION
### Related Item(s)
Issue #57 

### Changes
- I changed the placeholder text to a different gray that satisfies the colour contrast requirement

### Testing
Steps:
1. Go to customize chart tab
2. Observe the placeholder text colour

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-editor/62)
<!-- Reviewable:end -->
