### PR TITLE
Adjusted tooltip behaviour: is visible when sidebar is expanded

### DIFF
--- a/src/components/side-menu.vue
+++ b/src/components/side-menu.vue
@@ -12,7 +12,6 @@
                     delay: '200',
                     placement: 'right',
                     content: expanded ? $t('editor.collapse') : $t('editor.expand'),
-                    onShow: () => !expanded,
                     animateFill: true
                 }"
             >


### PR DESCRIPTION
### Related Item(s)
Issue #56 

### Changes
Now, when the sidebar is expanded, hovering over the enhancer icon displays a tooltip with the label _Collapse_.

### Testing
Steps:
1. Expand the sidebar
2. Hover over the enhancer icon
3. Tooltip with label _Collapse_ appears

![Screenshot 2025-05-12 140242](https://github.com/user-attachments/assets/0f57dd30-1a04-4bea-b5cd-0d71313c04c7)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-editor/65)
<!-- Reviewable:end -->
