### PR TITLE
Highlight icons

### DIFF
--- a/src/components/side-menu.vue
+++ b/src/components/side-menu.vue
@@ -41,11 +41,13 @@
                         delay: '200',
                         placement: 'right',
                         content: $t('editor.data.title'),
+                        onShow: () => !expanded,
                         animateFill: true
                     }"
                 >
                     <svg
                         class="flex-shrink-0"
+                        :class="{ 'bg-gray-200 rounded-md': $route.name  === 'Data' }"
                         width="24"
                         height="24"
                         viewBox="0 0 24 24"
@@ -75,11 +77,13 @@
                         delay: '200',
                         placement: 'right',
                         content: $t('editor.toc.chartType'),
+                        onShow: () => !expanded,
                         animateFill: true
                     }"
                 >
                     <svg
                         class="flex-shrink-0"
+                        :class="{ 'bg-gray-200 rounded-md': $route.name  === 'ChartType'}"
                         xmlns="http://www.w3.org/2000/svg"
                         width="24"
                         height="24"
@@ -121,11 +125,13 @@
                         delay: '200',
                         placement: 'right',
                         content: $t('editor.toc.chartCustomize'),
+                        onShow: () => !expanded,
                         animateFill: true
                     }"
                 >
                     <svg
                         class="flex-shrink-0"
+                        :class="{ 'bg-gray-200 rounded-md': $route.name === 'Customization'}"
                         xmlns="http://www.w3.org/2000/svg"
                         width="24"
                         height="24"


### PR DESCRIPTION
### Related Item(s)
Issue #58 

### Changes
- Icons on the sidebar are highlighted when visiting that page
- Sidebar expansion button highlighted when sidebar is expanded
- Tooltips for each icon now only show when the sidebar is not expanded

### Testing
Steps:
1. Hover over icons when sidebar not expanded versus expanded
2. Press the different buttons on the sidebar
3. Observe highlighted icons

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-editor/66)
<!-- Reviewable:end -->
