### PR TITLE
Advanced editor resizable

### DIFF
--- a/src/components/config-customization.vue
+++ b/src/components/config-customization.vue
@@ -220,7 +220,11 @@ const addAriaLabel = () => {
 }
 
 :deep(.jsoneditor-vue) {
-    height: 100vh;
+    height: 60vh;
+    resize: vertical;
+    overflow: auto;
+    min-height: 20vh;
+    max-height: 80vh;
 }
 
 :deep(.jsoneditor-modes) {


### PR DESCRIPTION
### Related Item(s)
Issue #59 

### Changes
- The advanced editor now starts off smaller and can be vertically resized

### Notes
- I added max height but let me know if I should remove that, I think it keeps the page cleaner

### Testing
Steps:
1. Go to the customization tab
2. Go to advanced tab
3. Observe a smaller advanced editor
4. Resize vertically on the bottom right

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-editor/67)
<!-- Reviewable:end -->
