### PR TITLE
customization chart stretches the entire width of page

### DIFF
--- a/src/components/config-customization.vue
+++ b/src/components/config-customization.vue
@@ -2,7 +2,7 @@
     <div class="chart-customization m-6" v-if="Object.keys(chartConfig).length">
         <div class="text-2xl font-bold">{{ $t('editor.customization.title') }}</div>
         <!-- header nav section for customization options -->
-        <div class="mt-8 w-1/2">
+        <div class="mt-8 w-full">
             <div class="flex justify-around">
                 <div
                     v-for="(section, idx) in sections"


### PR DESCRIPTION
### Related Item(s)
Issue #44 

### Changes
- Instead of the tabs adjusting to half page width, I made it adjust to the full width

### Testing
Steps:
1. Go to customization tab
2. Resize window and notice that the tabs use up all the empty space
