### PR TITLE
Fixed drag and drop for file upload

### DIFF
--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -23,6 +23,7 @@ editor.data.drag,Drag and drop file here,1,Glissez et déposez le fichier ici,1
 editor.data.filename,File name,1,Nom de fichier,1
 editor.data.upload,Select file from device,1,Sélectionner un fichier sur l'appareil,1
 editor.data.supported,"Supported file types: csv, xls, xlsx",1,"Types de fichiers pris en charge : csv, xls, xlsx",1
+editor.data.unsupported,"Unsupported file type. Please upload a csv, xls, or xlsx file.",1,"Type de fichier non pris en charge. Veuillez télécharger un fichier csv, xls ou xlsx.",1
 editor.data.import,Import data from file,1,Importer des données à partir d'un fichier,1
 editor.data.import.instructions,You may only upload one file at a time. You may remove this file to select another.,1,Vous ne pouvez télécharger qu'un seul fichier à la fois. Vous pouvez supprimer ce fichier pour en sélectionner un autre.,1
 editor.data.paste,Paste your data,1,Collez vos données,1


### PR DESCRIPTION
### Related Item(s)
Issue #43 

### Changes
- Added `@dragover` and `@dragleave` event to the drop zone
- Added an error message if user uploads incorrect file type

### Testing
Steps:
1. Open File Explorer 
2. Drag and drop any csv, xls, or xlsx file
3. File will be successfully loaded and can import data from file

Steps to see error message: 
1. Drag and drop any file that is not supported 
2. Error message in red will appear
3. Error message goes away when correct file type is uploaded

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-editor/70)
<!-- Reviewable:end -->
