### PR TITLE
Fixing default chart name to change according to language

### DIFF
--- a/src/components/chart-selection.vue
+++ b/src/components/chart-selection.vue
@@ -111,8 +111,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onBeforeMount, onMounted } from 'vue';
+import { computed, ref, onBeforeMount, onMounted, watch } from 'vue';
 import { useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
 import { useChartStore } from '../stores/chartStore';
 import { useDataStore } from '../stores/dataStore';
 
@@ -121,8 +122,20 @@ import dataModule from 'highcharts/modules/data';
 
 dataModule(Highcharts);
 
+const { t, locale } = useI18n();
+
 const chartStore = useChartStore();
 const chartConfig = computed(() => chartStore.chartConfig);
+
+let prevTitle = t('editor.customization.titles.chartTitle');
+
+watch(locale, () => {
+    const title = t('editor.customization.titles.chartTitle');
+    if (!chartStore.chartConfig.title.text || chartStore.chartConfig.title.text === prevTitle) {
+        chartStore.chartConfig.title.text = title;
+    }
+    prevTitle = title;
+});
 
 const dataStore = useDataStore();
 const seriesNames = computed(() => Object.values(dataStore.headers).slice(1));

--- a/src/components/data-table.vue
+++ b/src/components/data-table.vue
@@ -165,7 +165,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, ref, inject, onBeforeUnmount, onMounted, nextTick } from 'vue';
+import { computed, reactive, ref, inject, onBeforeUnmount, onMounted, nextTick, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useDataStore } from '../stores/dataStore';
 import { useChartStore } from '../stores/chartStore';
 
@@ -173,6 +174,8 @@ import Highcharts from 'highcharts';
 import dataModule from 'highcharts/modules/data';
 
 dataModule(Highcharts);
+
+const { t, locale } = useI18n();
 
 const props = defineProps({
     uploadedFile: {
@@ -192,6 +195,16 @@ const chartStore = useChartStore();
 const headers = computed(() => dataStore.headers);
 const gridData = computed(() => dataStore.gridData);
 const chartConfig = computed(() => chartStore.chartConfig);
+
+let prevTitle = t('editor.customization.titles.chartTitle');
+
+watch(locale, () => {
+    const title = t('editor.customization.titles.chartTitle');
+    if (!chartStore.chartConfig.title.text || chartStore.chartConfig.title.text === prevTitle) {
+        chartStore.chartConfig.title.text = title;
+    }
+    prevTitle = title;
+});
 
 const headerInput = ref<(HTMLInputElement | null)[]>([]);
 const gridCellInput = ref<(HTMLInputElement | null)[]>([]);
@@ -233,6 +246,7 @@ onMounted(() => {
                     .slice(1)
                     .map((_, colIdx) => dataStore.gridData.map((row) => parseFloat(row[colIdx + 1])));
                 chartStore.setupConfig(Object.values(dataStore.headers).slice(1), categories, seriesData);
+                chartStore.chartConfig.title.text = t('editor.customization.titles.chartTitle');
             },
             error: (err) => {
                 console.error('Error parsing file: ', err);

--- a/src/components/helpers/titles-customization.vue
+++ b/src/components/helpers/titles-customization.vue
@@ -27,11 +27,28 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useChartStore } from '../../stores/chartStore';
 
+const { t, locale } = useI18n();
 const chartStore = useChartStore();
 const chartConfig = computed(() => chartStore.chartConfig);
+
+if (!chartStore.chartConfig.title.text) {
+    chartStore.chartConfig.title.text = t('editor.customization.titles.chartTitle');
+}
+
+// watching for language change and update depending on language
+let prevTitle = t('editor.customization.titles.chartTitle');
+
+watch(locale, () => {
+    const title = t('editor.customization.titles.chartTitle');
+    if (!chartStore.chartConfig.title.text || chartStore.chartConfig.title.text === prevTitle) {
+        chartStore.chartConfig.title.text = title;
+    }
+    prevTitle = title;
+});
 </script>
 
 <style lang="scss"></style>

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -63,6 +63,7 @@ editor.customization.axes.na,No axes available for this chart type,1,Aucun axe d
 editor.customization.required,(required),1,(obligatoire),1
 editor.customization.optional,(optional),1,(facultatif),1
 editor.customization.titles.chart,Chart title,1,Titre du graphique,1
+editor.customization.titles.chartTitle,Basic Chart,1,Graphique de Base,1
 editor.customization.titles.subtitle,Chart sub-title,1,Sous-titre du graphique,1
 editor.customization.titles.placeholder,Untitled chart,1,Graphique sans titre,1
 editor.customization.advanced,Advanced,1,Avancé,1

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -90,7 +90,7 @@ export const useChartStore = defineStore('chartProperties', {
         setupConfig(seriesNames: string[], cats: string[], seriesData: number[][]): void {
             this.chartConfig = {
                 title: {
-                    text: 'Basic Chart'
+                    text: ''
                 },
                 subtitle: {
                     text: ''


### PR DESCRIPTION
### Related Item(s)
Issue #55 

### Changes
- Added a watcher to update default chart title when switching languages. 
- Makes sure that the title does **not** change when changing languages if user has manually entered a title. 

### Testing
Steps:
1. Upload and import data
2. On `Data` page, toggle the French/Anglais switch and the default chart name `Basic Chart` changes according to language
3. Can repeat the same check in `Templates` tab.
4. Repeat check in `Customization` tab. The input field and chart title should both change according to language.
5. Enter a custom name for the chart.
6. Toggling the language switch does not change the custom chart title.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-editor/75)
<!-- Reviewable:end -->
