### PR TITLE
second graph data series unselect properly

### DIFF
--- a/src/components/chart-selection.vue
+++ b/src/components/chart-selection.vue
@@ -215,6 +215,7 @@ const handleHybridSelection = (): void => {
     if (hybridChartType.value !== chartType.value && hybridChartType.value !== 'none') {
         const hybridSeries = enableMultiselect.value ? selectedHybridSeries.value : [seriesNames.value[1]];
         chartStore.updateHybridChart(hybridSeries, hybridChartType.value);
+        handleChartSelection();
     } else {
         // set all data series to original chart type (case for hybrid chart type being 'none' or same as main chart type)
         chartStore.setHybridChartType('none');

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -418,11 +418,12 @@ export const useChartStore = defineStore('chartProperties', {
         updateHybridChart(hybridSeries: string[], hybridType: string): void {
             this.setHybridChartType(hybridType);
             this.chartConfig.series.forEach((series, index) => {
-                if (hybridSeries.includes(series.name)) {
+            const isHybrid = hybridSeries.includes(series.name);
+                if (isHybrid) {
                     // TODO: may need to adjust based on what hybrid options become available in the future
                     const baseConfig = {
                         name: series.name,
-                        type: hybridType,
+                        type: isHybrid ? hybridType : this.chartType,
                         color: series.color,
                         dashStyle: 'solid',
                         data: series.data,


### PR DESCRIPTION
### Related Item(s)
Issue #42 

### Changes
- [FEATURE] Unselecting data series for second graph should now correctly update preview
- [FIX] When a data series is removed from hybridseries array, it is assigned back to original chart type

### Testing
Steps:
1. Go to templates
2. add a second graph
3. select any data series
4. observe graph change
5. deselect the data series
6. observe graph change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-editor/76)
<!-- Reviewable:end -->
