### PR TITLE
Fixing hidden "Select template for graph 2" 

### DIFF
--- a/src/components/chart-selection.vue
+++ b/src/components/chart-selection.vue
@@ -130,11 +130,11 @@ const seriesNames = computed(() => Object.values(dataStore.headers).slice(1));
 const router = useRouter();
 
 const enableHybrid = computed(() => {
-    return Array.isArray(chartConfig.value.series) && chartConfig.value.series.length >= 2;
+    return Array.isArray(chartConfig.value.series) && chartConfig.value.series.length >= 2 && chartType.value != 'pie';
 });
 
 const enableMultiselect = computed(() => {
-    return Array.isArray(chartConfig.value.series) && chartConfig.value.series.length > 2;
+    return Array.isArray(chartConfig.value.series) && chartConfig.value.series.length >= 2 && chartType.value != 'pie';
 });
 
 const chartType = ref<string>('');
@@ -197,6 +197,11 @@ const handleChartSelection = (): void => {
     loading.value = true;
     const otherSeries = enableMultiselect.value ? selectedHybridSeries.value : [seriesNames.value[1]];
     const seriesToUpdate = seriesNames.value.filter((name) => !otherSeries.includes(name));
+
+    if (chartType.value === 'pie') {
+        hybridChartType.value = 'none';
+        selectedHybridSeries.value = [];
+    }
 
     chartStore.updateConfig(chartType.value, seriesToUpdate, dataStore.headers, dataStore.gridData);
 

--- a/src/components/helpers/data-customization.vue
+++ b/src/components/helpers/data-customization.vue
@@ -217,8 +217,11 @@ onBeforeMount(() => {
     activeDataSeries.value = props.dataSeries[0];
     chartType.value = (activeSeries.value as SeriesData).type;
     if (chartType.value === 'pie') {
-        for (let i = 0; i < (activeSeries.value as SeriesData).colors!.length; i++) {
-            showPieColourPicker[i] = false;
+        const activeSeriesColors = (activeSeries.value as SeriesData)?.colors;
+        if (activeSeriesColors) {
+            activeSeriesColors.forEach((_, i) => {
+                showPieColourPicker[i] = false;
+            });
         }
     }
 });

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -269,6 +269,7 @@ export const useChartStore = defineStore('chartProperties', {
                       }
                     : series
             );
+            this.chartConfig.legend = { enabled: true };
         },
 
         /* Update highcharts configuration for bar chart **/
@@ -287,6 +288,7 @@ export const useChartStore = defineStore('chartProperties', {
                       }
                     : series
             );
+            this.chartConfig.legend = { enabled: true };
         },
 
         /* Update highcharts configuration for scatter plot **/
@@ -340,6 +342,7 @@ export const useChartStore = defineStore('chartProperties', {
                         : series
                 );
             }
+            this.chartConfig.legend = { enabled: true };
         },
 
         /* Update highcharts configuration for column chart **/
@@ -358,6 +361,7 @@ export const useChartStore = defineStore('chartProperties', {
                       }
                     : series
             );
+            this.chartConfig.legend = { enabled: true };
         },
 
         /* Update highcharts configuration for area chart **/
@@ -374,6 +378,7 @@ export const useChartStore = defineStore('chartProperties', {
                       }
                     : series
             );
+            this.chartConfig.legend = { enabled: true };
         },
 
         /* Update highcharts configuration for spline chart **/
@@ -390,6 +395,7 @@ export const useChartStore = defineStore('chartProperties', {
                       }
                     : series
             );
+            this.chartConfig.legend = { enabled: true };
         },
 
         /* Update highcharts configuration for pie chart **/
@@ -398,20 +404,28 @@ export const useChartStore = defineStore('chartProperties', {
             // this.chartConfig.series = this.chartConfig.series.map((series, index) =>
             //     seriesNames.includes(series.name) ? { name: seriesNames[0], type: 'pie', data: seriesData[index] } : series
             // );
-            this.chartConfig = {
-                title: { text: 'Basic Chart' },
-                subtitle: {
-                    text: ''
-                },
-                series: [
-                    {
-                        name: seriesNames[0],
+
+            // TODO: this is the default selection: make it so that user can choose which series to display
+            const selectedSeries = seriesNames[0];
+
+            this.chartConfig.series = this.chartConfig.series.map((series) => {
+                if (series.name === selectedSeries) {
+                    return {
+                        ...series,
                         type: 'pie',
                         data: seriesData,
-                        colors: this.defaultColours
-                    }
-                ]
-            };
+                        color: this.defaultColours[0]
+                    };
+                } else {
+                    return {
+                        ...series,
+                        data: [],
+                        type: 'line'
+                    };
+                }
+            });
+
+            this.chartConfig.legend = { enabled: false };
         },
 
         /* Update highcharts configuration for hybrid chart **/


### PR DESCRIPTION
### Related Item(s)
Issues #47 and #77

### Changes
- Now, if you switch from one chart type to **Pie** chart, then back to a different chart type, the `Select template for graph 2` selector reappears, without requiring an intermediate switch to **Scatterplot** first.
- Previous data values/points are restored after changing from **Pie** chart back to a different chart.

### Testing
Steps:
1. Upload and import data.
2. Go to templates and change type of Graph 1 to **Pie chart**.
3. The `Select template for graph 2` selector disappears.
4.  Change back to another chart type. 
5.  For any chart type selection, the `Select template for graph 2` selector reappears and data is restored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-editor/78)
<!-- Reviewable:end -->
