### PR TITLE
working solution to not crash on empty second graph/empty first graph

### DIFF
--- a/src/components/chart-selection.vue
+++ b/src/components/chart-selection.vue
@@ -210,6 +210,7 @@ const handleChartSelection = (): void => {
 
     if (enableHybrid.value && hybridChartType.value === chartType.value) {
         chartStore.setHybridChartType('none');
+        selectedHybridSeries.value = [];
     }
 
     // set brief timeout to allow chart to re-render
@@ -220,14 +221,17 @@ const handleChartSelection = (): void => {
 
 // modify the chart config to adapt to hybrid chart setup
 const handleHybridSelection = (): void => {
-    if (hybridChartType.value !== chartType.value && hybridChartType.value !== 'none') {
-        const hybridSeries = enableMultiselect.value ? selectedHybridSeries.value : [seriesNames.value[1]];
-        chartStore.updateHybridChart(hybridSeries, hybridChartType.value);
+    if (
+        hybridChartType.value !== chartType.value &&
+        hybridChartType.value !== 'none' &&
+        selectedHybridSeries.value.length > 0
+    ) {
+        chartStore.updateHybridChart(selectedHybridSeries.value, hybridChartType.value);
         handleChartSelection();
     } else {
-        // set all data series to original chart type (case for hybrid chart type being 'none' or same as main chart type)
         chartStore.setHybridChartType('none');
         selectedHybridSeries.value = [];
+
         handleChartSelection();
     }
 };

--- a/src/components/config-customization.vue
+++ b/src/components/config-customization.vue
@@ -41,7 +41,7 @@
         <template v-else-if="activeSection === 'dataSeries'">
             <div
                 class="flex mt-4"
-                v-if="chartStore.hybridChartType && chartStore.hybridChartType !== chartStore.chartType"
+                v-if="chartStore.hybridChartType && chartStore.hybridChartType !== chartStore.chartType && hybridDataSeries.length > 0"
             >
                 <data-customization
                     :dataSeries="mainDataSeries"

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -435,8 +435,8 @@ export const useChartStore = defineStore('chartProperties', {
         updateHybridChart(hybridSeries: string[], hybridType: string): void {
             this.setHybridChartType(hybridType);
             this.chartConfig.series.forEach((series, index) => {
-            const isHybrid = hybridSeries.includes(series.name);
-                if (isHybrid) {
+                if (hybridSeries.includes(series.name)) {
+                    const isHybrid = hybridSeries.includes(series.name);
                     // TODO: may need to adjust based on what hybrid options become available in the future
                     const baseConfig = {
                         name: series.name,


### PR DESCRIPTION
### Related Item(s)
Issue #45 

### Changes
- In the templates tab, when user chooses a second graph template but does not select a data series or unselects all data series, you can now go to customization and still use the data series tab without console errors and program crashes

### Notes
- I made a lot of changes to basically check for null/undefined and I am not sure if this is the most effective method but it works (I hope)

### Testing
Steps:
1. go to templates tab
2. select a template for the second graph but don't choose any data series (or choose any data series and unselect them)
3. go to customization tab
4. click on data series
5. observe that it is functional

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-editor/80)
<!-- Reviewable:end -->
