### PR TITLE
options stay selected for hybrid graph

### DIFF
--- a/src/components/chart-selection.vue
+++ b/src/components/chart-selection.vue
@@ -159,7 +159,10 @@ const hybridChartTemplates: Record<string, string> = {
     spline: 'spline'
 };
 
-let selectedHybridSeries = ref<string[]>([]);
+const selectedHybridSeries = computed({
+  get: () => chartStore.selectedHybridSeries,
+  set: (val: string[]) => chartStore.setSelectedHybridSeries(val),
+});
 
 const loading = ref<boolean>(true);
 

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -17,6 +17,7 @@ export const useChartStore = defineStore('chartProperties', {
         hybridChartType: '' as string,
         chartSeries: [] as string[],
         chartConfig: {} as HighchartsConfig,
+        selectedHybridSeries: [] as string[],
         defaultColours: [
             '#2caffe',
             '#544fc5',
@@ -433,6 +434,13 @@ export const useChartStore = defineStore('chartProperties', {
                     this.chartConfig.series[index] = baseConfig;
                 }
             });
+        },
+        setSelectedHybridSeries(series: string[]) {
+            this.selectedHybridSeries = series;
+        },
+
+        getSelectedHybridSeries() {
+            return this.selectedHybridSeries;
         }
     }
 });


### PR DESCRIPTION
### Related Item(s)
Issue #76 

### Changes
- when you select data series for the hybrid graph, they stay selected when you move to other tabs
-
### Testing
Steps:
1. Go to templates tab
2. Choose a second graph template and any data series
3. Go to a different tab (data, customization) then go back to templates
4. Observe the selections still there

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-editor/83)
<!-- Reviewable:end -->
