### PR TITLE
Allows for pie chart customization

### DIFF
--- a/src/components/data-table.vue
+++ b/src/components/data-table.vue
@@ -223,6 +223,16 @@ const colActions: Record<string, string> = {
 };
 
 onMounted(() => {
+    const config = chartStore.chartConfig;
+
+    let seriesArray: any[] = [];
+    if (Array.isArray(config.series)) {
+        seriesArray = config.series;
+    } else if (config.series && 'data' in config.series && Array.isArray(config.series.data)) {
+        seriesArray = config.series.data;
+    }
+    const isPieChart = seriesArray.length >= 1 && seriesArray[0].type === 'pie';
+
     if (props.uploadedFile || props.pastedFile) {
         // parse uploaded file or pasted data
         $papa.parse(props.uploadedFile || props.pastedFile, {
@@ -249,9 +259,8 @@ onMounted(() => {
                 console.error('Error parsing file: ', err);
             }
         });
-    }else if (Object.keys(chartStore.chartConfig).length > 0) {
-        const config = chartStore.chartConfig;
-
+        // TODO: will need a case for pie charts as well 
+    } else if (Object.keys(chartStore.chartConfig).length > 0 && !isPieChart) {
         const headers = [chartStore.categoryLabel || ''].concat(config.series.map((s) => s.name));
         dataStore.setHeaders(headers);
 

--- a/src/components/helpers/data-customization.vue
+++ b/src/components/helpers/data-customization.vue
@@ -7,11 +7,19 @@
                 class="border border-black w-full p-2 rounded appearance-none cursor-pointer"
                 v-model="activeDataSeries"
                 :aria-label="$t('editor.customization.dataSeries')"
+                @change="changeChartType(false)"
             >
                 <!-- Enable insert when exactly one row is selected, enable delete when any number of rows are selected -->
-                <option v-for="series in dataSeries" :value="series">
-                    {{ series }}
-                </option>
+                <template v-if="chartType === 'pie'">
+                    <option v-for="series in allSeriesNames" :key="series" :value="series">
+                        {{ series }}
+                    </option>
+                </template>
+                <template v-else>
+                    <option v-for="series in dataSeries" :value="series">
+                        {{ series }}
+                    </option>
+                </template>
             </select>
             <div class="select-arrow absolute right-2 top-1/2"></div>
         </div>
@@ -33,7 +41,7 @@
                     class="border border-black w-full p-2 rounded appearance-none cursor-pointer"
                     v-model="chartType"
                     :aria-label="$t('editor.customization.data.seriesType')"
-                    @change="changeChartType"
+                    @change="changeChartType()"
                 >
                     <option v-for="series in Object.keys(seriesOptions)" :key="series" :value="series">
                         {{ $t(`editor.customization.data.series.${series}`) }}
@@ -185,6 +193,14 @@ const activeSeries = computed(() => {
         return chartConfig.value.series;
     }
 });
+
+const allSeriesNames = computed(() => {
+    if (Array.isArray(chartConfig.value.series)) {
+        return chartConfig.value.series.map((s) => s.name);
+    }
+    return [];
+});
+
 const showColourPicker = ref<boolean>(false);
 const showPieColourPicker = ref<boolean[]>([]);
 
@@ -213,11 +229,20 @@ const markerOptions: Record<string, string> = {
 };
 
 onBeforeMount(() => {
+    const series = chartConfig.value.series;
     activeDataSeries.value = props.dataSeries[0] ?? '';
     chartType.value = activeSeries.value?.type ?? '';
-    if (chartType.value === 'pie' && Array.isArray(activeSeries.value?.colors)) {
-        for (let i = 0; i < activeSeries.value.colors.length; i++) {
-            showPieColourPicker[i] = false;
+    if (chartType.value === 'pie') {
+        // To ensure that dropdown and colours reflect the graph being displayed when switching back to the data series tab
+        if (Array.isArray(series)) {
+            const visiblePie = series.find((s) => s.type === 'pie' && s.visible !== false);
+            activeDataSeries.value = visiblePie?.name || series[0]?.name || '';
+        }
+        const activeSeriesColors = (activeSeries.value as SeriesData)?.colors;
+        if (activeSeriesColors) {
+            activeSeriesColors.forEach((_, i) => {
+                showPieColourPicker[i] = false;
+            });
         }
     }
 });
@@ -234,14 +259,30 @@ const updatePieColour = (index: number, color: string) => {
     }
 };
 
-const changeChartType = () => {
-    emit('loading', true);
-    const seriesNames = Object.values(dataStore.headers).slice(1);
-    chartStore.updateConfig(chartType.value, seriesNames, dataStore.headers, dataStore.gridData);
-    // set brief timeout to allow chart to re-render
-    setTimeout(() => {
-        emit('loading', false);
-    }, 100);
+const changeChartType = (updateChart = true) => {
+    if (updateChart || chartType.value === 'pie') {
+        emit('loading', true);
+        const selectedSeries = activeDataSeries.value;
+        const seriesNames = Object.values(dataStore.headers).slice(1);
+
+        let currentColours: string[] = [];
+        if (activeSeries.value && 'name' in activeSeries.value && Array.isArray(activeSeries.value.colors)) {
+            currentColours = [...activeSeries.value.colors];
+        }
+
+        chartStore.updateConfig(
+            chartType.value,
+            seriesNames,
+            dataStore.headers,
+            dataStore.gridData,
+            chartType.value === 'pie' ? selectedSeries : undefined,
+            currentColours
+        );
+        // set brief timeout to allow chart to re-render
+        setTimeout(() => {
+            emit('loading', false);
+        }, 100);
+    }
 
     if (chartType.value === 'pie' && activeSeries.value?.colors) {
         for (let i = 0; i < activeSeries.value.colors.length; i++) {
@@ -278,9 +319,8 @@ select {
     background: none;
 }
 
-.selector{
-    width:100%;
-    max-width:300px;
+.selector {
+    width: 100%;
+    max-width: 300px;
 }
-
 </style>

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -50,4 +50,5 @@ export interface SeriesData {
     };
     dashStyle?: string;
     data?: number[];
+    visible?: boolean;
 }


### PR DESCRIPTION
### Related Item(s)
Issue #82 

### Changes
- Updated the `Data Series` dropdown in the `Customization Chart` tab to allow selecting a different data series to be displayed when chart type is set to Pie. 
- Fixed the colour customization logic for Pie charts.  

### Notes
* These changes currently do not apply when switching from a Hybrid chart back to a Single chart. 
 
### Testing
Steps:
1. In templates, choose `Pie chart`.
2. Go to `Customize Chart` tab via sidebar or button in the bottom-right corner. 
3. Select `Data Series` tab.
4. Use the dropdown to select a different data series to be displayed in the pie chart.
5. Confirm that the pie chart updates to reflect the selected data series, and that you can successfully change the colours of individual pie sections.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-editor/85)
<!-- Reviewable:end -->
