### PR TITLE
Fixing smaller screen issues for customize chart section

### DIFF
--- a/src/components/config-customization.vue
+++ b/src/components/config-customization.vue
@@ -3,11 +3,11 @@
         <div class="text-2xl font-bold">{{ $t('editor.customization.title') }}</div>
         <!-- header nav section for customization options -->
         <div class="mt-8 w-full">
-            <div class="flex justify-around">
+            <div class="tab-container grid grid-cols-4">
                 <div
                     v-for="(section, idx) in sections"
                     :key="idx"
-                    class="cursor-pointer py-2 px-4 flex-1 text-center"
+                    class="tab-label cursor-pointer py-2 px-2 flex-1 text-center"
                     tabindex="0"
                     :class="{ 'font-semibold': activeSection === section }"
                     @click="() => {
@@ -19,10 +19,15 @@
                     @keydown.enter="() => (activeSection = section)"
                 >
                     {{ $t(`editor.customization.${section}`) }}
+                     <!-- small screen nav bar -->
+                    <div 
+                        class="nav-underline h-1 flex-1 transition-all" 
+                        :class="activeSection === section ? 'bg-black' : 'bg-gray-300'">
+                    </div>
                 </div>
             </div>
-            <!-- nav bar -->
-            <div class="flex">
+            <!-- big screen nav bar -->
+            <div class="nav-tab flex">
                 <div
                     v-for="section in sections"
                     :key="section"
@@ -231,7 +236,7 @@ const addAriaLabel = () => {
     display: none;
 }
 
-:deep(.jsoneditor-poweredBy) {
+:deep(.jsoneditor-poweredBy), .nav-underline {
     display: none;
 }
 
@@ -245,5 +250,41 @@ const addAriaLabel = () => {
 
 :deep(.ace-jsoneditor .ace_constant.ace_numeric) {
     color: #8B0000;
+}
+
+@media (max-width: 472px) {
+    .tab-container {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .nav-tab {
+        display: none;
+    }
+
+    .tab-label {
+        align-self: flex-end;
+    }
+
+    .nav-underline {
+        display: flex;  
+        align-items: stretch;
+    }
+}
+
+@media (max-width: 280px) {
+    .tab-container {
+        display: flex;
+        overflow-x: auto;
+    }
+
+    .nav-underline {
+        display: none;
+    }
+
+    .tab-label {
+        padding-left: 1rem;
+        padding-right: 1rem;  
+        align-self: center; 
+    }
 }
 </style>


### PR DESCRIPTION
### Related Item(s)
Issue #79 

### Changes
- Within the Customize Chart section, on a smaller screen, the header now takes up the entire screen, and the sidebar takes up the entire height. 
- The transition bar for the 4 subsections is no longer misaligned, because the transition bar adapts to different screen sizes.

### Testing
Steps:
1. Go to the customize chart section.
2. Press f12 and make the screen size smaller.
3. The header and sidebar span the full width and height of the screen respectively.
4. At around 282-470px for width, the transition bars appear correctly underneath their respective subsections.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-editor/87)
<!-- Reviewable:end -->
