### PR TITLE
better datatable cell edit sizing

### DIFF
--- a/src/components/data-table.vue
+++ b/src/components/data-table.vue
@@ -78,27 +78,20 @@
                             :key="colIdx"
                         >
                             <div class="flex items-center w-full">
-                                <span
-                                    class="col-header flex-grow truncate"
-                                    v-if="editingHeader !== colIdx"
-                                    tabindex="0"
-                                    @click="editColHeader(colIdx)"
-                                    @focus="editColHeader(colIdx)"
-                                >
-                                    {{ header || $t('editor.untitled') }}
-                                </span>
                                 <input
-                                    v-else
                                     :ref="(el) => (headerInput[colIdx] = el as HTMLInputElement | null)"
-                                    class="col-header flex-grow w-0 max-w-[80%] box-border border border-black p-1"
+                                    class="col-header max-w-[calc(100%-21px)] box-border border border-transparent p-1 bg-transparent focus:border-black focus:bg-white"
                                     type="text"
                                     v-model="headers[colIdx]"
+                                    :style="{ width: Math.max(header.length + 2, 8) + 'ch' }"
+                                    :readonly="editingHeader !== colIdx"
                                     @input="updateHeader(colIdx, headers[colIdx])"
+                                    @focus="editColHeader(colIdx)"
                                     @blur="escEditCell"
-                                    @keyup.enter="escEditCell"
+                                    @keyup.enter="($event.target as HTMLElement).blur()"
                                 />
                                 <input
-                                    class="ml-2"
+                                    class="ml-auto"
                                     type="checkbox"
                                     v-model="selectedCols[colIdx]"
                                     :aria-label="$t('editor.datatable.selectCol')"
@@ -129,38 +122,28 @@
                             @click="editCell(rowIdx, colIdx, value)"
                         >
                             <div class="flex items-center w-full">
-                                <span
-                                    class="grid-cell flex-grow truncate"
-                                    v-if="editingCell.rowIdx !== rowIdx || editingCell.colIdx !== colIdx"
-                                    tabindex="0"
-                                    @click="editCell(rowIdx, colIdx, value)"
-                                    @focus="editCell(rowIdx, colIdx, value)"
-                                >
-                                    {{ value }}
-                                </span>
-
                                 <input
-                                    v-else
                                     :ref="
                                         (el) =>
                                             (gridCellInput[rowIdx * headers.length + colIdx] =
                                                 el as HTMLInputElement | null)
                                     "
-                                    class="grid-cell flex-grow w-0 max-w-[80%] box-border border border-black p-1"
+                                    class="grid-cell max-w-[calc(100%-2px)] box-border border border-transparent p-1 bg-transparent focus:border-black focus:bg-white"
                                     type="text"
-                                    v-model="editingVal"
-                                    tabindex="0"
+                                    v-model="gridData[rowIdx][colIdx]"
+                                    :style="{ width: Math.max(gridData[rowIdx][colIdx].length + 2, 8) + 'ch' }"
+                                    :readonly="editingCell.rowIdx !== rowIdx || editingCell.colIdx !== colIdx"
                                     @input="updateCell(rowIdx, colIdx, ($event.target as HTMLInputElement).value)"
+                                    @focus="editCell(rowIdx, colIdx, gridData[rowIdx][colIdx])"
                                     @blur="escEditCell"
-                                    @keyup.enter="escEditCell"
+                                    @keyup.enter="($event.target as HTMLElement).blur()"
                                 />
                             </div>
                         </td>
                         <td
                             class="border border-dotted border-gray-400 p-2"
                             :aria-label="$t('editor.datatable.addNewCol')"
-                        >
-                        </td>
+                        ></td>
                     </tr>
                     <tr :class="gridData.length % 2 === 0 ? 'bg-gray-50' : ''">
                         <td
@@ -255,11 +238,11 @@ const toggleAllRows = () => {
 const addNewRow = () => {
     dataStore.addNewRow(gridData.value.length - 1, true);
     chartStore.insertRow(gridData.value.length);
-}
+};
 const addNewCol = () => {
-    dataStore.addNewCol(headers.value.length - 1, true); 
-    chartStore.insertColumn(headers.value.length); 
-}
+    dataStore.addNewCol(headers.value.length - 1, true);
+    chartStore.insertColumn(headers.value.length);
+};
 const rowActions: Record<string, string> = {
     delete: 'delete',
     insertAbove: 'insertAbove',


### PR DESCRIPTION
### Related Item(s)
Issue #88 

### Changes
- I made the cell editing box size based on the number of characters in the content
- Made it so even when you are editing the header, the checkbox stays aligned on the right side

### Notes
- this is not really a perfect fix for the issue, the editing box can still slightly change the size of the cell but now it is much more consistent and reasonable
- Not really sure how I can make it exactly the same given the nature of span vs input if you have any ideas please let me know!
- There are also very minor changes just from the prettier formatting

### Testing
Steps:
1. Load the test data
2. Edit the headers and cells
3. Notice the checkbox is always aligned on the right in the headers
4. Notice the input box is consistently sized based on number of characters in the content

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-editor/92)
<!-- Reviewable:end -->
