### PR TITLE
Entire header space can now be clicked to edit

### DIFF
--- a/src/components/data-table.vue
+++ b/src/components/data-table.vue
@@ -79,7 +79,7 @@
                             :key="colIdx"
                             @click="editColHeader(colIdx)"
                         >
-                            <div class="flex items-center w-full">
+                            <div class="flex items-center w-full" style="cursor: text;">
                                 <input
                                     :ref="(el) => (headerInput[colIdx] = el as HTMLInputElement | null)"
                                     class="col-header max-w-[calc(100%-21px)] box-border border border-transparent font-bold p-1 bg-transparent focus:border-black focus:bg-white rounded-md"
@@ -126,7 +126,7 @@
                             :key="colIdx"
                             @click="editCell(rowIdx, colIdx, value)"
                         >
-                            <div class="flex items-center w-full">
+                            <div class="flex items-center w-full" style="cursor: text;">
                                 <input
                                     :ref="
                                         (el) =>


### PR DESCRIPTION
### Related Item(s)
Issue #108 

### Changes
- Instead of just the editing box, you can now click anywhere in the header to edit the text
- Also darkened some border colours to meet WCAG standards

### Notes
I did test with borders and backgrounds to show that the area is editable but it looks very tacky in my opinion (borders have to be dark enough to meet WCAG standards, I don't think there is any requirement for the background colour one)

Some examples:
<img width="568" height="297" alt="image" src="https://github.com/user-attachments/assets/f311ddba-2f7f-470f-9185-7eaaf8909460" />
<img width="568" height="297" alt="image" src="https://github.com/user-attachments/assets/34ab9874-0b49-4267-9706-469a52a2a6e9" />
If anyone thinks either of these are fine or has a better idea please let me know, in the PR I have no background or border

### Testing
Steps:
1. Upload data file
2. Press anywhere in the headers to edit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/109)
<!-- Reviewable:end -->
