### PR TITLE
Fix scatter plots incorrectly formatting config

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -36,6 +36,16 @@ export interface HighchartsConfig {
         };
         enabled?: boolean;
     };
+    legend?: {
+        enabled?: boolean;
+    };
+    tooltip?: {
+        footerFormat?: string;
+        format?: string;
+        headerFormat?: string;
+        pointFormat?: string;
+        useHTML?: boolean;
+    };
     series: SeriesData[] | { data: SeriesData[] };
 }
 export interface SeriesData {


### PR DESCRIPTION
### Related Item(s)
Closes #110, #112

### Changes
- [FIX] scatter plots formatting incorrect series data format as previously `typeof` always returns object

### Testing
Steps:
1. Upload data
2. Change chart type to scatter plot
3. X axis labels should still be properly named
4. Return to data table and all data should be there

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="48" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/117)
<!-- Reviewable:end -->
