### PR TITLE
Support config formats of old highcharts editor using data csv property

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -161,7 +161,7 @@ onMounted(() => {
     // if passed an existing highcharts config as prop, load and jump to datatable view
     if (props.config && Object.keys(props.config).length) {
         chartStore.setChartConfig(props.config);
-        dataStore.extractGridData(props.config);
+        dataStore.extractGridData(chartStore.chartConfig);
         setTimeout(() => {
             dataStore.setDatatableView(true);
         }, 0);

--- a/src/components/side-menu.vue
+++ b/src/components/side-menu.vue
@@ -402,7 +402,7 @@ const handleConfigFileUpload = (event: Event) => {
         const res = JSON.parse(e.target?.result as string);
         chartStore.setChartConfig(res);
         // extract data from the config file
-        dataStore.extractGridData(res);
+        dataStore.extractGridData(chartStore.chartConfig);
     };
     reader.readAsText(configFile);
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -24,6 +24,7 @@ export interface HighchartsConfig {
         categories: (number | string)[];
     };
     data?: {
+        csv: string;
         csvURL: string;
         enablePolling: boolean;
     };

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -50,6 +50,7 @@ HACK.datatable.rowActions.delete,Delete row(s),1,Supprimer des lignes,1
 HACK.datatable.rowActions.insertBelow,Insert below,1,Insérer ci-dessous,1
 HACK.datatable.rowActions.insertAbove,Insert above,1,Insérer ci-dessus,1
 HACK.datatable.selectAllRows,Select all rows,1,Sélectionner toutes les lignes,1
+HACK.datatable.colHeaders,Column headers,1,En-têtes de colonnes,0
 HACK.datatable.colActions,Column actions,1,Actions de colonne,1
 HACK.datatable.colActions.delete,Delete column(s),1,Supprimer des colonnes,1
 HACK.datatable.colActions.insertLeft,Insert left,1,Insérer à gauche,1

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -35,7 +35,7 @@ export const useChartStore = defineStore('chartProperties', {
     }),
 
     actions: {
-        /* Reset store to initial state **/
+        /** Reset store to initial state */
         resetStore(): void {
             this.chartType = 'line';
             this.defaultTitle = '';
@@ -57,32 +57,32 @@ export const useChartStore = defineStore('chartProperties', {
             ];
         },
 
-        /* Set highcharts type **/
+        /** Set highcharts type */
         setChartType(chartType: string): void {
             this.chartType = chartType;
         },
 
-        /* Set hybrid highcharts type **/
+        /** Set hybrid highcharts type */
         setHybridChartType(chartType: string): void {
             this.hybridChartType = chartType;
         },
 
-        /* Set default title for highcharts **/
+        /** Set default title for highcharts */
         setDefaultTitle(title: string): void {
             this.defaultTitle = title;
         },
 
-        /* Clear highcharts config **/
+        /** Clear highcharts config */
         clearChartConfig(): void {
             this.chartConfig = {};
         },
 
-        /* Set context/export menu strings **/
+        /** Set context/export menu strings */
         setMenuOptions(menuOptions: ExportMenuOptions): void {
             this.chartConfig.lang = menuOptions;
         },
 
-        /* Set highcharts config (from imported json file) **/
+        /** Set highcharts config (from imported json file) */
         setChartConfig(chartConfig: HighchartsConfig): void {
             // add mandatory fields blank (for customization section)
             // TODO: tons of edge cases here depending on the complexity of a chart configuration
@@ -122,9 +122,49 @@ export const useChartStore = defineStore('chartProperties', {
                     }
                 }))
             };
+
+            // handle special case for highcharts configs using data property
+            if (chartConfig.data && chartConfig.data.csv) {
+                this.convertCsvToSeries();
+            }
         },
 
-        /* Set default highcharts config **/
+        /** Convert CSV data to series data in config */
+        convertCsvToSeries(): void {
+            // split CSV string into lines
+            const lines = this.chartConfig.data?.csv.trim().split('\n') as string[];
+            const header = lines[0].split(';').map((h) => h.replace(/"/g, '').trim());
+            const categories = header.slice(1);
+
+            // extract series data in the format "name;val1;val2"
+            const seriesData = [];
+            for (let i = 1; i < lines.length; i++) {
+                const values = lines[i].split(';').map((val: string) => val.trim());
+                const seriesName = values[0];
+                seriesData.push({
+                    name: seriesName,
+                    data: values.slice(1).map((val: string) => parseInt(val)),
+                    type: 'line',
+                    color: this.defaultColours[i-1],
+                    dashStyle: 'solid',
+                    marker: {
+                        symbol: 'circle'
+                    }
+                });
+            }
+
+            // fill in extracted values (catos, x-axis title, series data) into chart config
+            this.chartConfig.xAxis = {
+                categories: categories,
+                title: {
+                    text: header[0] || ''
+                }
+            };
+            this.chartConfig.series = seriesData;
+            delete this.chartConfig.data;
+        },
+
+        /** Set default highcharts config */
         setupConfig(seriesNames: string[], cats: string[], seriesData: number[][], categoryLabel = ''): void {
             this.chartConfig = {
                 title: {
@@ -158,7 +198,7 @@ export const useChartStore = defineStore('chartProperties', {
             this.setChartType('line');
         },
 
-        /* Update highcharts configuration for chart type **/
+        /** Update highcharts configuration for chart type */
         updateConfig(
             type: string,
             series: string[],
@@ -248,7 +288,7 @@ export const useChartStore = defineStore('chartProperties', {
             }
         },
 
-        /* Update data series after deleting row(s) **/
+        /** Update data series after deleting row(s) */
         deleteRow(rowIdxs: number[]): void {
             const sortedRowIdxs = [...rowIdxs].sort((a, b) => b - a);
             // assuming all indices are valid
@@ -260,7 +300,7 @@ export const useChartStore = defineStore('chartProperties', {
             });
         },
 
-        /* Update data series after deleting column(s) **/
+        /** Update data series after deleting column(s) */
         deleteColumn(colIdxs: number[]): void {
             const sortedColIdxs = [...colIdxs].sort((a, b) => b - a);
             sortedColIdxs.forEach((colIdx: number) => {
@@ -268,7 +308,7 @@ export const useChartStore = defineStore('chartProperties', {
             });
         },
 
-        /* Update data series after inserting row **/
+        /** Update data series after inserting row */
         insertRow(rowIdx: number): void {
             this.chartConfig.xAxis.categories.splice(rowIdx, 0, '');
             this.chartConfig.series.forEach((series: SeriesData) => {
@@ -276,7 +316,7 @@ export const useChartStore = defineStore('chartProperties', {
             });
         },
 
-        /* Update data series after inserting column **/
+        /** Update data series after inserting column */
         insertColumn(colIdx: number): void {
             const defaultData = new Array(this.chartConfig.xAxis.categories.length).fill(0);
             const newSeries: SeriesData = {
@@ -287,7 +327,7 @@ export const useChartStore = defineStore('chartProperties', {
             (this.chartConfig.series as SeriesData[]).splice(colIdx - 1, 0, newSeries);
         },
 
-        /* Update header (series names) value **/
+        /** Update header (series names) value */
         updateHeader(colIdx: number, name: string): void {
             if (colIdx === 0) {
                 this.chartConfig.xAxis.title.text = name;
@@ -296,7 +336,7 @@ export const useChartStore = defineStore('chartProperties', {
             }
         },
 
-        /* Update a single series value after data grid cell has been modified **/
+        /** Update a single series value after data grid cell has been modified */
         updateVal(rowIdx: number, colIdx: number, val: string): void {
             if (colIdx) {
                 this.chartConfig.series[colIdx - 1].data[rowIdx] = parseInt(val);
@@ -305,7 +345,7 @@ export const useChartStore = defineStore('chartProperties', {
             }
         },
 
-        /* Update highcharts configuration for line chart **/
+        /** Update highcharts configuration for line chart */
         updateLineChart(seriesNames: string[], seriesData: number[][]): void {
             this.chartConfig.series = this.chartConfig.series.map((series, index) =>
                 seriesNames.includes(series.name)
@@ -322,7 +362,7 @@ export const useChartStore = defineStore('chartProperties', {
             this.chartConfig.legend = { enabled: true };
         },
 
-        /* Update highcharts configuration for bar chart **/
+        /** Update highcharts configuration for bar chart */
         updateBarChart(seriesNames: string[], seriesData: number[][]): void {
             this.chartConfig.series = this.chartConfig.series.map((series, index) =>
                 seriesNames.includes(series.name)
@@ -341,7 +381,7 @@ export const useChartStore = defineStore('chartProperties', {
             this.chartConfig.legend = { enabled: true };
         },
 
-        /* Update highcharts configuration for scatter plot **/
+        /** Update highcharts configuration for scatter plot */
         updateScatterPlot(seriesNames: string[], seriesData: { x: number; y: number }[] | number[][]): void {
             this.chartConfig.series = this.chartConfig.series.map((series, index) =>
                 seriesNames.includes(series.name)
@@ -367,7 +407,7 @@ export const useChartStore = defineStore('chartProperties', {
             };
         },
 
-        /* Update highcharts configuration for column chart **/
+        /** Update highcharts configuration for column chart */
         updateColumnChart(seriesNames: string[], seriesData: number[][]): void {
             this.chartConfig.series = this.chartConfig.series.map((series, index) =>
                 seriesNames.includes(series.name)
@@ -386,7 +426,7 @@ export const useChartStore = defineStore('chartProperties', {
             this.chartConfig.legend = { enabled: true };
         },
 
-        /* Update highcharts configuration for area chart **/
+        /** Update highcharts configuration for area chart */
         updateAreaChart(seriesNames: string[], seriesData: number[][]): void {
             this.chartConfig.series = this.chartConfig.series.map((series, index) =>
                 seriesNames.includes(series.name)
@@ -403,7 +443,7 @@ export const useChartStore = defineStore('chartProperties', {
             this.chartConfig.legend = { enabled: true };
         },
 
-        /* Update highcharts configuration for spline chart **/
+        /** Update highcharts configuration for spline chart */
         updateSplineChart(seriesNames: string[], seriesData: number[][]): void {
             this.chartConfig.series = this.chartConfig.series.map((series, index) =>
                 seriesNames.includes(series.name)
@@ -420,7 +460,7 @@ export const useChartStore = defineStore('chartProperties', {
             this.chartConfig.legend = { enabled: true };
         },
 
-        /* Update highcharts configuration for pie chart **/
+        /** Update highcharts configuration for pie chart */
         updatePieChart(
             seriesNames: string[],
             seriesIndex: number,
@@ -453,7 +493,7 @@ export const useChartStore = defineStore('chartProperties', {
             this.chartConfig.legend = { enabled: false };
         },
 
-        /* Update highcharts configuration for hybrid chart **/
+        /** Update highcharts configuration for hybrid chart */
         updateHybridChart(hybridSeries: string[], hybridType: string): void {
             this.setHybridChartType(hybridType);
             this.chartConfig.series.forEach((series, index) => {

--- a/src/stores/dataStore.ts
+++ b/src/stores/dataStore.ts
@@ -9,7 +9,7 @@ export const useDataStore = defineStore('chartData', {
         datatableView: false
     }),
     actions: {
-        /* Reset store to initial state **/
+        /** Reset store to initial state */
         resetStore(): void {
             this.headers = [];
             this.gridData = [];
@@ -17,22 +17,22 @@ export const useDataStore = defineStore('chartData', {
             this.datatableView = false;
         },
 
-        /* Initially set column headers **/
+        /** Initially set column headers */
         setHeaders(headers: string[]): void {
             this.headers = headers;
         },
 
-        /* Initially set grid data when uploaded new file **/
+        /** Initially set grid data when uploaded new file */
         setGridData(data: string[][]): void {
             this.gridData = data;
         },
 
-        /* Set if data section should show datatable **/
+        /** Set if data section should show datatable */
         setDatatableView(datatableView: boolean): void {
             this.datatableView = datatableView;
         },
 
-        /* Set flag if user has uploaded valid chart data format **/
+        /** Set flag if user has uploaded valid chart data format */
         toggleUploaded(uploaded: boolean): void {
             this.uploaded = uploaded;
         },
@@ -71,19 +71,19 @@ export const useDataStore = defineStore('chartData', {
             }
         },
 
-        /* Update cell value in grid data **/
+        /** Update cell value in grid data */
         updateCell(row: number, col: number, value: string): void {
             if (this.gridData[row]) {
                 this.gridData[row][col] = value;
             }
         },
 
-        /* Delete row(s) from grid data **/
+        /** Delete row(s) from grid data */
         deleteRows(selectedRowIdxs: string[]): void {
             this.gridData = this.gridData.filter((_, idx) => !selectedRowIdxs.includes(idx.toString()));
         },
 
-        /* Add new row to grid data **/
+        /** Add new row to grid data */
         addNewRow(selectedRowIdx: string, below: boolean = true): void {
             const newRow = this.headers.map(() => '');
             const newIdx = parseInt(selectedRowIdx);
@@ -95,7 +95,7 @@ export const useDataStore = defineStore('chartData', {
             }
         },
 
-        /* Delete column(s) from grid data **/
+        /** Delete column(s) from grid data */
         deleteCols(selectedColIdxs: string[]): void {
             // sort indices in descending to avoid issues with shifting
             const selectedIdxs = selectedColIdxs
@@ -114,7 +114,7 @@ export const useDataStore = defineStore('chartData', {
             });
         },
 
-        /* Add new column to grid data **/
+        /** Add new column to grid data */
         addNewCol(selectedColIdx: string, right: boolean = true): void {
             const newCol = '';
             // determine new position based on insert right/left


### PR DESCRIPTION
### Related Item(s)
Closes #102 

### Changes
- support highcharts with data formatted as a single string in the `data.csv` property (default config output of using old highcharts editor) and properly populate HACK interface data

### Testing
Import this file (taken from old Storylines product) in side menu with "import existing chart": 
[old-chart.json](https://github.com/user-attachments/files/21373796/old-chart.json)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/119)
<!-- Reviewable:end -->
