### PR TITLE
icons now highlight on plugin version

### DIFF
--- a/src/components/side-menu.vue
+++ b/src/components/side-menu.vue
@@ -83,7 +83,7 @@
                     <svg
                         class="flex-shrink-0"
                         :class="{
-                            'bg-gray-200 rounded-md': $route.name === 'Data' || currentView === CurrentView.Data
+                            'bg-gray-200 rounded-md': $route.name === 'Data' || pluginView === CurrentView.Data
                         }"
                         width="24"
                         height="24"
@@ -170,8 +170,7 @@
                     <svg
                         class="flex-shrink-0"
                         :class="{
-                            'bg-gray-200 rounded-md':
-                                $route.name === 'ChartType' || currentView === CurrentView.Template
+                            'bg-gray-200 rounded-md': $route.name === 'ChartType' || pluginView === CurrentView.Template
                         }"
                         xmlns="http://www.w3.org/2000/svg"
                         width="24"
@@ -254,7 +253,10 @@
                 >
                     <svg
                         class="flex-shrink-0"
-                        :class="{ 'bg-gray-200 rounded-md': $route.name === 'Customization' }"
+                        :class="{
+                            'bg-gray-200 rounded-md':
+                                $route.name === 'Customization' || pluginView === CurrentView.Customization
+                        }"
                         xmlns="http://www.w3.org/2000/svg"
                         width="24"
                         height="24"
@@ -371,7 +373,7 @@ defineProps({
     lang: {
         type: String
     },
-    currentView: {
+    pluginView: {
         type: String
     }
 });


### PR DESCRIPTION
### Related Item(s)
Issue #125 

### Changes
- Icons now highlight properly on plugin version on RESPECT

### Testing
Steps:
1. build as plugin for RESPECT
2. create or edit a chart
3. notice icons highlighting when switching tabs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/129)
<!-- Reviewable:end -->
