### PR TITLE
Add support for bilingual charts

### DIFF
--- a/HighchartsSchema.json
+++ b/HighchartsSchema.json
@@ -209,7 +209,19 @@
                             "symbol": { "type": "string" }
                         }
                     },
-                    "name": { "type": "string" },
+                    "name": {
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "object",
+                                "properties": {
+                                    "en": { "type": "string" },
+                                    "fr": { "type": "string" }
+                                },
+                                "required": ["en", "fr"]
+                            }
+                        }
+                    },
                     "opacity": { "type": "number" },
                     "tooltip": {
                         "type": "object",
@@ -232,14 +244,30 @@
         "subtitle": {
             "type": "object",
             "properties": {
-                "text": { "type": "string" }
+                "text": {
+                    "type": "object",
+                    "properties": {
+                        "en": { "type": "string" },
+                        "fr": { "type": "string" }
+                    },
+                    "required": ["en", "fr"],
+                    "additionalProperties": false
+                }
             },
             "required": ["text"]
         },
         "title": {
             "type": "object",
             "properties": {
-                "text": { "type": "string" }
+                "text": {
+                    "type": "object",
+                    "properties": {
+                        "en": { "type": "string" },
+                        "fr": { "type": "string" }
+                    },
+                    "required": ["en", "fr"],
+                    "additionalProperties": false
+                }
             },
             "required": ["text"]
         },
@@ -259,14 +287,28 @@
             "properties": {
                 "categories": {
                     "type": "array",
-                    "items": { "type": "string" }
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "en": { "type": "string" },
+                            "fr": { "type": "string" }
+                        }
+                    }
                 },
                 "min": { "type": "number" },
                 "max": { "type": "number" },
                 "title": {
                     "type": "object",
                     "properties": {
-                        "text": { "type": "string" }
+                        "text": {
+                            "type": "object",
+                            "properties": {
+                                "en": { "type": "string" },
+                                "fr": { "type": "string" }
+                            },
+                            "required": ["en", "fr"],
+                            "additionalProperties": false
+                        }
                     }
                 }
             }
@@ -279,7 +321,15 @@
                 "title": {
                     "type": "object",
                     "properties": {
-                        "text": { "type": "string" }
+                        "text": {
+                            "type": "object",
+                            "properties": {
+                                "en": { "type": "string" },
+                                "fr": { "type": "string" }
+                            },
+                            "required": ["en", "fr"],
+                            "additionalProperties": false
+                        }
                     }
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "highcharts": "^11.4.8",
                 "highcharts-vue": "^2.0.1",
                 "jsonschema": "^1.4.1",
+                "jszip": "^3.10.1",
                 "marked": "^17.0.5",
                 "pinia": "^3.0.4",
                 "sass": "^1.80.6",
@@ -2126,6 +2127,12 @@
                 "url": "https://opencollective.com/core-js"
             }
         },
+        "node_modules/core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "license": "MIT"
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2895,6 +2902,12 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+            "license": "MIT"
+        },
         "node_modules/immutable": {
             "version": "5.1.4",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
@@ -2927,6 +2940,12 @@
             "engines": {
                 "node": ">=0.8.19"
             }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "license": "ISC"
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -3001,6 +3020,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/mesqueeb"
             }
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -3095,6 +3120,18 @@
                 "node": "*"
             }
         },
+        "node_modules/jszip": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+            "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+            "license": "(MIT OR GPL-3.0-or-later)",
+            "dependencies": {
+                "lie": "~3.3.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "^1.0.5"
+            }
+        },
         "node_modules/keyv": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3117,6 +3154,15 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/lie": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+            "license": "MIT",
+            "dependencies": {
+                "immediate": "~3.0.5"
             }
         },
         "node_modules/lightningcss": {
@@ -3678,6 +3724,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "license": "(MIT AND Zlib)"
+        },
         "node_modules/papaparse": {
             "version": "5.5.3",
             "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
@@ -3991,6 +4043,12 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "license": "MIT"
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4030,6 +4088,21 @@
             "license": "MIT",
             "dependencies": {
                 "pify": "^2.3.0"
+            }
+        },
+        "node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "node_modules/readdirp": {
@@ -4165,6 +4238,12 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
+        "node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "license": "MIT"
+        },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4201,6 +4280,12 @@
             "bin": {
                 "semver": "bin/semver.js"
             }
+        },
+        "node_modules/setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "license": "MIT"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -4247,6 +4332,15 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
             }
         },
         "node_modules/strip-bom": {
@@ -4638,7 +4732,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "highcharts": "^11.4.8",
         "highcharts-vue": "^2.0.1",
         "jsonschema": "^1.4.1",
+        "jszip": "^3.10.1",
         "marked": "^17.0.5",
         "pinia": "^3.0.4",
         "sass": "^1.80.6",

--- a/src/app.vue
+++ b/src/app.vue
@@ -74,6 +74,8 @@ import { useChartStore } from './stores/chartStore';
 import { useDataStore } from './stores/dataStore';
 import { useI18n } from 'vue-i18n';
 import { CurrentView, HighchartsConfig } from './definitions';
+import type { LangId } from './definitions';
+import { buildContextMenuLabels } from './utils/contextMenu';
 
 import SideMenu from './components/side-menu.vue';
 import Spinner from './components/helpers/spinner.vue';
@@ -93,6 +95,9 @@ const props = defineProps({
     },
     title: {
         type: String
+    },
+    bilingual: {
+        type: Boolean
     }
 });
 
@@ -103,28 +108,20 @@ const i18n = useI18n();
 const { t } = useI18n();
 const chartStore = useChartStore();
 const dataStore = useDataStore();
-const appLang = ref('');
+const appLang = ref<LangId>('en');
 const saving = ref<boolean>(false);
 const currentView = ref<CurrentView>(CurrentView.Data);
 
-const contextMenuLabels = computed(() => ({
-    viewFullscreen: t('HACK.export.viewFullscreen'),
-    printChart: t('HACK.export.printChart'),
-    downloadPNG: t('HACK.export.downloadPNG'),
-    downloadJPEG: t('HACK.export.downloadJPEG'),
-    downloadPDF: t('HACK.export.downloadPDF'),
-    downloadSVG: t('HACK.export.downloadSVG'),
-    downloadCSV: t('HACK.export.downloadCSV'),
-    downloadXLS: t('HACK.export.downloadXLS'),
-    viewData: t('HACK.export.viewData')
-}));
+const resolvedChartConfig = chartStore.resolvedChartConfig;
+const activeLang = computed(() => chartStore.activeLang);
+
+const contextMenuLabels = computed(() => buildContextMenuLabels(t, activeLang.value));
 
 const isMobile = ref(false);
 
 const checkScreenSize = () => {
     isMobile.value = window.innerWidth < 1024;
 };
-
 
 const getTemplate = (): Component => {
     const pluginComponent: Record<CurrentView | string, Component> = {
@@ -143,16 +140,19 @@ if (!props.title) {
         const title = t('HACK.customization.titles.chartTitle');
         if (!chartStore.chartConfig || !chartStore.chartConfig.title) {
             chartStore.chartConfig = chartStore.chartConfig || {};
-            chartStore.chartConfig.title = chartStore.chartConfig.title || { text: '' };
+            chartStore.chartConfig.title = chartStore.chartConfig.title || { text: { en: '', fr: '' } };
         }
-        if (!chartStore.chartConfig.title.text || chartStore.chartConfig.title.text === prevTitle) {
-            chartStore.chartConfig.title.text = title;
+        if (
+            !chartStore.chartConfig.title.text[appLang.value] ||
+            chartStore.chartConfig.title.text[appLang.value] === prevTitle
+        ) {
+            chartStore.chartConfig.title.text[appLang.value] = title;
         }
         prevTitle = title;
     });
 }
 
-watch(i18n.locale, () => {
+watch(activeLang, () => {
     // set context menu labels based on the current language
     chartStore.setMenuOptions(contextMenuLabels.value);
     chartStore.refreshKey += 1;
@@ -161,7 +161,7 @@ watch(i18n.locale, () => {
 onMounted(() => {
     checkScreenSize();
     window.addEventListener('resize', checkScreenSize);
-    appLang.value = i18n.locale.value;
+    appLang.value = i18n.locale.value as LangId;
     // set locale only when standalone usage
     if (!props.plugin) {
         i18n.locale.value = appLang.value;
@@ -174,10 +174,12 @@ onMounted(() => {
         chartStore.setMenuOptions(contextMenuLabels.value);
     }
 
+    chartStore.isBilingual = !props.plugin || !!props.bilingual;
+
     // if passed an existing highcharts config as prop, load and jump to datatable view
     if (props.config && Object.keys(props.config).length) {
         chartStore.setChartConfig(props.config);
-        dataStore.extractGridData(chartStore.chartConfig);
+        dataStore.extractGridData(resolvedChartConfig);
         setTimeout(() => {
             dataStore.setDatatableView(true);
         }, 0);
@@ -192,6 +194,10 @@ onMounted(() => {
 const changeLang = (): void => {
     appLang.value = appLang.value === 'en' ? 'fr' : 'en';
     i18n.locale.value = appLang.value;
+
+    if (props.plugin && !chartStore.isBilingual) {
+        chartStore.activeLang = appLang.value;
+    }
 };
 
 const changeView = (view: CurrentView): void => {

--- a/src/components/chart-selection.vue
+++ b/src/components/chart-selection.vue
@@ -72,20 +72,20 @@
                 >
                     <div
                         v-for="(series, index) in chartConfig.series"
-                        :key="series.name"
+                        :key="series.name[activeLang]"
                         class="p-2 cursor-pointer hover:bg-gray-200"
-                        @click="toggleHybridSeries(series.name)"
+                        @click="toggleHybridSeries(series.name[activeLang])"
                     >
                         <input
                             type="checkbox"
                             :value="index"
-                            :checked="selectedHybridSeries.includes(series.name)"
+                            :checked="selectedHybridSeries.includes(series.name[activeLang])"
                             :disabled="
                                 selectedHybridSeries.length >= chartConfig.series.length - 1 &&
-                                !selectedHybridSeries.includes(series.name)
+                                !selectedHybridSeries.includes(series.name[activeLang])
                             "
                         />
-                        <span class="ml-2">{{ series.name }}</span>
+                        <span class="ml-2">{{ series.name[activeLang] }}</span>
                     </div>
                 </div>
             </div>
@@ -95,7 +95,7 @@
         <div v-if="!loading">
             <div class="font-bold mt-6">{{ $t('HACK.preview') }}</div>
             <div class="dv-chart-container items-stretch h-full w-full mt-2">
-                <highchart :key="chartStore.refreshKey" :options="chartConfig"></highchart>
+                <highchart :key="chartStore.refreshKey" :options="chartStore.resolvedChartConfig"></highchart>
             </div>
         </div>
 
@@ -149,6 +149,7 @@ const props = defineProps({
 const chartStore = useChartStore();
 const sidemenuStore = useSidemenuStore();
 const chartConfig = computed(() => chartStore.chartConfig);
+const activeLang = computed(() => chartStore.activeLang);
 
 const dataStore = useDataStore();
 const seriesNames = computed(() => Object.values(dataStore.headers).slice(1));
@@ -228,7 +229,6 @@ onMounted(() => {
     const seriesData = dataStore.headers
         .slice(1)
         .map((_, colIdx) => dataStore.gridData.map((row) => parseFloat(row[colIdx + 1])));
-
 });
 
 onBeforeUnmount(() => {
@@ -239,7 +239,11 @@ onBeforeUnmount(() => {
 const handleChartSelection = (): void => {
     loading.value = true;
     const otherSeries = enableMultiselect.value ? selectedHybridSeries.value : [seriesNames.value[1]];
-    const seriesToUpdate = seriesNames.value.filter((name) => !otherSeries.includes(name));
+    const seriesToUpdate = seriesNames.value.filter(
+        (name) =>
+            typeof name !== 'string' &&
+            !otherSeries.map((s) => (typeof s !== 'string' ? s[activeLang.value] : s)).includes(name[activeLang.value])
+    );
 
     if (chartType.value === 'pie') {
         hybridChartType.value = 'none';

--- a/src/components/config-customization.vue
+++ b/src/components/config-customization.vue
@@ -37,6 +37,10 @@
             </div>
         </div>
 
+        <div v-if="activeSection === 'chartTitles' || activeSection === 'axes'">
+            <LanguageTabs v-model:activeLang="chartStore.activeLang" />
+        </div>
+
         <!-- Configure chart titles -->
         <template v-if="activeSection === 'chartTitles'">
             <titles-customization />
@@ -111,7 +115,7 @@
             <div class="font-bold mt-6">{{ $t('HACK.preview') }}</div>
             <!-- Preview of chart -->
             <div class="dv-chart-container items-stretch h-full w-full mt-2">
-                <highchart :key="chartStore.refreshKey" :options="chartConfig"></highchart>
+                <highchart :key="chartStore.refreshKey" :options="chartStore.resolvedChartConfig"></highchart>
             </div>
         </div>
     </div>
@@ -128,6 +132,7 @@ import { Validator } from 'jsonschema';
 import { useI18n } from 'vue-i18n';
 import schema from '../../HighchartsSchema.json';
 
+import LanguageTabs from './helpers/language-tabs.vue'
 import TitlesCustomization from './helpers/titles-customization.vue';
 import DataCustomization from './helpers/data-customization.vue';
 import AxesCustomization from './helpers/axes-customization.vue';

--- a/src/components/data-section.vue
+++ b/src/components/data-section.vue
@@ -90,6 +90,26 @@
                 </div>
             </div>
 
+            <div v-if="fileName" class="mb-4 p-4 border rounded bg-gray-50">
+                <div class="text-lg font-bold text-gray-700">
+                    {{ $t('HACK.data.upload.lang') }}
+                </div>
+                <span class="inline-block mb-2 text-gray-600">
+                    {{ $t('HACK.data.upload.lang.description') }}
+                </span>
+
+                <div class="flex space-x-2">
+                    <button
+                        v-for="lang in langs"
+                        :key="lang"
+                        :class="getBtnClass(lang)"
+                        @click="(dataStore.setUploadedFileLang(lang), chartStore.setActiveLang(lang))"
+                    >
+                        {{ lang.toUpperCase() }}
+                    </button>
+                </div>
+            </div>
+
             <div class="mt-4 flex flex-col sm:flex-row gap-4">
                 <button
                     class="bg-black text-white rounded border border-black hover:bg-gray-900 font-bold p-4"
@@ -148,6 +168,8 @@ import { useDataStore } from '../stores/dataStore';
 import { useChartStore } from '../stores/chartStore';
 import { useSidemenuStore } from '../stores/sidemenuStore';
 import { CurrentView } from '../definitions';
+import type { LangId } from '../definitions';
+import { useI18n } from 'vue-i18n';
 
 import PasteData from './helpers/paste-data.vue';
 import DataTable from './data-table.vue';
@@ -163,6 +185,7 @@ const props = defineProps({
     }
 });
 
+const { locale } = useI18n();
 const chartStore = useChartStore();
 const dataStore = useDataStore();
 const sidemenuStore = useSidemenuStore();
@@ -190,6 +213,16 @@ const hidePage = computed(() => {
 const checkScreenSize = () => {
     isSmallScreen.value = window.innerWidth <= 500;
 };
+
+const langs = computed<LangId[]>(() => {
+    const current = locale.value as LangId;
+    return current === 'fr' ? ['fr', 'en'] : ['en', 'fr'];
+});
+
+const getBtnClass = (lang: LangId) => [
+    'px-4 py-2 rounded',
+    dataStore.uploadedFileLang === lang ? 'bg-gray-600 text-white' : 'bg-gray-200 text-gray-700'
+];
 
 onMounted(() => {
     checkScreenSize();

--- a/src/components/data-table.vue
+++ b/src/components/data-table.vue
@@ -59,6 +59,7 @@
             </div>
         </div>
 
+        <LanguageTabs v-model:activeLang="chartStore.activeLang" />
         <!-- Datatable -->
         <div class="overflow-x-auto">
             <table class="table-auto border-collapse border-dotted border border-black w-full mt-5">
@@ -84,7 +85,7 @@
                                     :ref="(el) => (headerInput[colIdx] = el as HTMLInputElement | null)"
                                     class="col-header max-w-[calc(100%-21px)] box-border border border-transparent font-bold p-1 bg-transparent focus:border-black focus:bg-white rounded-md"
                                     type="text"
-                                    v-model="headers[colIdx]"
+                                    v-model="(headers[colIdx] as { [key: string]: string })[activeLang]"
                                     :aria-label="$t('HACK.datatable.colHeaders')"
                                     :style="{ width: Math.max(header.length + 2, 8) + 'ch' }"
                                     :readonly="editingHeader !== colIdx"
@@ -135,12 +136,16 @@
                                     "
                                     class="grid-cell max-w-[calc(100%-2px)] box-border border border-transparent bg-transparent p-1 focus:border-black focus:bg-white rounded-md"
                                     type="text"
-                                    v-model="gridData[rowIdx][colIdx]"
+                                    :value="getCellDisplayValue(rowIdx, colIdx)"
                                     :aria-label="$t('HACK.datatable.gridcells')"
-                                    :style="{ width: Math.max(gridData[rowIdx][colIdx].length + 2, 8) + 'ch' }"
+                                    :style="{
+                                        width:
+                                            Math.max(getCellDisplayValue(rowIdx, colIdx).toString().length + 2, 8) +
+                                            'ch'
+                                    }"
                                     :readonly="editingCell.rowIdx !== rowIdx || editingCell.colIdx !== colIdx"
                                     @input="updateCell(rowIdx, colIdx, ($event.target as HTMLInputElement).value)"
-                                    @focus="editCell(rowIdx, colIdx, gridData[rowIdx][colIdx])"
+                                    @focus="editCell(rowIdx, colIdx, getCellDisplayValue(rowIdx, colIdx))"
                                     @blur="escEditCell"
                                     @keyup.enter="($event.target as HTMLElement).blur()"
                                 />
@@ -172,7 +177,7 @@
         <div class="font-bold mt-8">{{ $t('HACK.preview') }}</div>
         <!-- Preview of chart -->
         <div class="dv-chart-container items-stretch h-full w-full mt-2">
-            <highchart :key="chartStore.refreshKey" :options="chartConfig"></highchart>
+            <highchart :key="chartStore.refreshKey" :options="chartStore.resolvedChartConfig"></highchart>
         </div>
 
         <div class="flex items-center mt-4">
@@ -200,11 +205,14 @@ import { useDataStore } from '../stores/dataStore';
 import { useChartStore } from '../stores/chartStore';
 import { useI18n } from 'vue-i18n';
 import { CurrentView } from '../definitions';
+import type { LocalizedString } from '../definitions';
 
 import Highcharts from 'highcharts';
 import dataModule from 'highcharts/modules/data';
 import exporting from 'highcharts/modules/exporting';
 import exportData from 'highcharts/modules/export-data';
+
+import LanguageTabs from './helpers/language-tabs.vue';
 
 exporting(Highcharts);
 exportData(Highcharts);
@@ -233,11 +241,9 @@ const $papa: any = inject('$papa');
 const dataStore = useDataStore();
 const chartStore = useChartStore();
 
+const activeLang = computed(() => chartStore.activeLang);
 const headers = computed(() => dataStore.headers);
 const gridData = computed(() => dataStore.gridData);
-const chartConfig = computed(() => {
-    return chartStore.chartConfig;
-});
 
 const headerInput = ref<(HTMLInputElement | null)[]>([]);
 const gridCellInput = ref<(HTMLInputElement | null)[]>([]);
@@ -299,24 +305,28 @@ onMounted(() => {
             header: true, // first row headers
             skipEmptyLines: true,
             complete: (res: any) => {
-                dataStore.setHeaders(res.meta.fields || []);
-                dataStore.setGridData(res.data.map((row: any) => dataStore.headers.map((header) => row[header])));
-
+                const bilingualHeaders = (res.meta.fields || []).map((h: string) => ({ en: h, fr: h }));
+                dataStore.setHeaders(bilingualHeaders);
+                dataStore.setGridData(
+                    res.data.map((row: any) =>
+                        bilingualHeaders.map((header: any, colIdx: number) => {
+                            const value = row[header.en] ?? '';
+                            return colIdx === 0 ? { en: value, fr: value } : value;
+                        })
+                    )
+                );
                 // default preview of datatable to line graph
                 const categories = dataStore.gridData.map((row) => row[0]);
-                const seriesData = dataStore.headers
+                const seriesData = bilingualHeaders
                     .slice(1)
                     .map((_, colIdx) => dataStore.gridData.map((row) => parseFloat(row[colIdx + 1])));
-                chartStore.setupConfig(
-                    Object.values(dataStore.headers).slice(1),
-                    categories,
-                    seriesData,
-                    dataStore.headers[0] || ''
-                );
+                chartStore.setupConfig(bilingualHeaders.slice(1), categories, seriesData, bilingualHeaders[0]);
 
                 // set a non-empty default chart title
-                chartStore.chartConfig.title.text =
-                    chartStore.defaultTitle || t('HACK.customization.titles.chartTitle');
+                chartStore.chartConfig.title.text = {
+                    en: chartStore.defaultTitle || t('HACK.customization.titles.chartTitle', {}, { locale: 'en' }),
+                    fr: chartStore.defaultTitle || t('HACK.customization.titles.chartTitle', {}, { locale: 'fr' })
+                };
             },
             error: (err: any) => {
                 console.error('Error parsing file: ', err);
@@ -325,7 +335,7 @@ onMounted(() => {
     } else if (Object.keys(chartStore.chartConfig).length > 0 && !isPieChart) {
         const config = chartStore.chartConfig;
 
-        const headers = [chartStore.chartConfig.xAxis.title.text || ''].concat(config.series.map((s) => s.name));
+        const headers = [config.xAxis.title.text || ''].concat(config.series.map((s) => s.name));
         dataStore.setHeaders(headers);
 
         const categories = config.xAxis?.categories || [];
@@ -384,14 +394,31 @@ const escEditCell = () => {
     editingVal.value = '';
 };
 
-const updateHeader = (headerIdx: number, val: string) => {
+const updateHeader = (headerIdx: number, val: LocalizedString) => {
     chartStore.updateHeader(headerIdx, val);
 };
 
 const updateCell = (rowIdx: number, colIdx: number, val: string) => {
-    dataStore.updateCell(rowIdx, colIdx, val);
+    const cell = dataStore.gridData[rowIdx][colIdx];
+
+    if (colIdx === 0 && typeof cell === 'object') {
+        cell[activeLang.value] = val;
+    } else {
+        dataStore.gridData[rowIdx][colIdx] = val;
+    }
+
+    dataStore.updateCell(rowIdx, colIdx, val, activeLang.value);
     // update chart config with new series value
     chartStore.updateVal(rowIdx, colIdx, val);
+};
+
+const getCellDisplayValue = (rowIdx: number, colIdx: number) => {
+    const cell = dataStore.gridData[rowIdx][colIdx];
+
+    if (colIdx === 0 && typeof cell === 'object') {
+        return cell[activeLang.value];
+    }
+    return cell ?? '';
 };
 
 const handleRowAction = (): void => {

--- a/src/components/helpers/axes-customization.vue
+++ b/src/components/helpers/axes-customization.vue
@@ -3,24 +3,30 @@
         <div v-if="chartConfig.series[0].type !== 'pie'">
             <div class="font-semibold mt-6">
                 {{ $t('HACK.customization.axes.xaxis') }}
+                <span v-if="chartStore.isBilingual">
+                    {{ activeLang === 'en' ? '(EN)' : '(FR)' }}
+                </span>
             </div>
             <input
                 class="border text-sm md:text-base border-black box-border w-full mt-2 p-2 pr-6"
                 :placeholder="$t('HACK.customization.axes.placeholder')"
                 :aria-label="$t('HACK.customization.axes.xaxis')"
                 type="text"
-                v-model="chartConfig.xAxis.title.text"
+                v-model="chartConfig.xAxis.title.text[activeLang]"
             />
 
             <div class="font-semibold mt-6">
                 {{ $t('HACK.customization.axes.yaxis') }}
+                <span v-if="chartStore.isBilingual">
+                    {{ activeLang === 'en' ? '(EN)' : '(FR)' }}
+                </span>
             </div>
             <input
                 class="border text-sm md:text-base border-black box-border w-full mt-2 p-2 pr-6"
                 :placeholder="$t('HACK.customization.axes.placeholder')"
                 :aria-label="$t('HACK.customization.axes.yaxis')"
                 type="text"
-                v-model="chartConfig.yAxis.title.text"
+                v-model="chartConfig.yAxis.title.text[activeLang]"
             />
         </div>
         <div class="mt-6" v-else>
@@ -35,6 +41,7 @@ import { useChartStore } from '../../stores/chartStore';
 
 const chartStore = useChartStore();
 const chartConfig = computed(() => chartStore.chartConfig);
+const activeLang = computed(() => chartStore.activeLang);
 </script>
 
 <style lang="scss"></style>

--- a/src/components/helpers/data-customization.vue
+++ b/src/components/helpers/data-customization.vue
@@ -11,13 +11,13 @@
             >
                 <!-- Enable insert when exactly one row is selected, enable delete when any number of rows are selected -->
                 <template v-if="chartType === 'pie'">
-                    <option v-for="series in allSeriesNames" :key="series" :value="series">
-                        {{ series }}
+                    <option v-for="series in allSeriesNames" :key="series[activeLang]" :value="series[activeLang]">
+                        {{ series[activeLang] }}
                     </option>
                 </template>
                 <template v-else>
                     <option v-for="(series, i) in dataSeries" :key="i" :value="i">
-                        {{ series }}
+                        {{ series[activeLang] }}
                     </option>
                 </template>
             </select>
@@ -170,10 +170,11 @@ import { computed, onBeforeMount, ref, watch } from 'vue';
 import { useDataStore } from '../../stores/dataStore';
 import { useChartStore } from '../../stores/chartStore';
 import { chart } from 'highcharts';
+import type { LocalizedString } from '@/definitions';
 
 const props = defineProps({
     dataSeries: {
-        type: Array<string>,
+        type: Array<LocalizedString>,
         required: true
     },
     chartType: {
@@ -199,6 +200,7 @@ watch(
 );
 
 const chartConfig = computed(() => chartStore.chartConfig);
+const activeLang = computed(() => chartStore.activeLang);
 
 const activeDataSeries = ref<number>(0);
 const activeSeries = computed(() => {

--- a/src/components/helpers/language-tabs.vue
+++ b/src/components/helpers/language-tabs.vue
@@ -1,0 +1,76 @@
+<template>
+    <div class="mt-4">
+        <div class="flex items-center border-b border-gray-300">
+            <!-- Language tabs: only show when bilingual is enabled (always true for standalone HACK) -->
+            <template v-if="chartStore.isBilingual">
+                <!-- Base language (language of uploaded file) -->
+                <button :class="tabClass(baseLang)" class="px-4 py-2" @click="$emit('update:activeLang', baseLang)">
+                    {{ $t(`HACK.lang.config.${baseLang}`) }}
+                </button>
+
+                <!-- Other language -->
+                <button
+                    :class="tabClass(otherLang)"
+                    class="px-4 py-2 relative"
+                    @click="($emit('update:activeLang', otherLang), (chartStore.showLangWarning = false))"
+                >
+                    {{ $t(`HACK.lang.config.${otherLang}`) }}
+                    <span v-if="chartStore.showLangWarning" class="ml-1 text-red-500">•</span>
+                </button>
+            </template>
+        </div>
+
+        <!-- Warning message -->
+        <div
+            v-if="chartStore.isBilingual && activeLang === baseLang && chartStore.showLangWarning"
+            class="mt-1 text-yellow-700 flex items-center px-4 gap-2"
+        >
+            {{ $t('HACK.lang.config.translate', { lang: $t(`HACK.lang.${otherLang}`) }) }}
+            <button
+                class="text-gray-500 hover:text-gray-700"
+                @click="chartStore.showLangWarning = false"
+                :aria-label="$t('HACK.lang.config.dismiss')"
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                >
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </button>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { useChartStore } from '@/stores/chartStore';
+import { useDataStore } from '@/stores/dataStore';
+import { computed } from 'vue';
+import type { LangId } from '@/definitions';
+
+const props = defineProps({
+    activeLang: {
+        type: String
+    }
+});
+
+defineEmits(['update:activeLang']);
+
+const chartStore = useChartStore();
+const dataStore = useDataStore();
+
+const baseLang = computed(() => dataStore.uploadedFileLang);
+const otherLang = computed(() => (baseLang.value === 'en' ? 'fr' : 'en'));
+
+const tabClass = (lang: LangId) =>
+    props.activeLang === lang ? 'border-b-2 border-blue-500 text-blue-500 font-bold' : 'text-gray-500';
+</script>
+
+<style lang="css" scoped>
+.button-uppercase {
+    text-transform: uppercase;
+}
+</style>

--- a/src/components/helpers/titles-customization.vue
+++ b/src/components/helpers/titles-customization.vue
@@ -2,26 +2,32 @@
     <div class="chart-customization-title">
         <div class="font-bold mt-6">
             {{ $t('HACK.customization.titles.chart') }}
+            <span v-if="chartStore.isBilingual">
+                {{ activeLang === 'en' ? '(EN) ' : '(FR) ' }}
+            </span>
             <span class="font-normal text-red-600">{{ $t('HACK.customization.required') }}</span>
         </div>
         <input
             class="border text-sm md:text-base border-black box-border w-full mt-2 p-2 pr-6"
-            :class="{ 'border-red-500': !chartConfig.title.text }"
+            :class="{ 'border-red-500': !chartConfig.title.text[activeLang] }"
             :placeholder="$t('HACK.customization.titles.placeholder')"
             :aria-label="$t('HACK.customization.titles.chart')"
             type="text"
-            v-model="chartConfig.title.text"
+            v-model="chartConfig.title.text[activeLang]"
         />
 
         <div class="font-bold mt-6">
             {{ $t('HACK.customization.titles.subtitle') }}
+            <span v-if="chartStore.isBilingual">
+                {{ activeLang === 'en' ? '(EN)' : '(FR)' }}
+            </span>
         </div>
         <input
             class="border text-sm md:text-base border-black box-border w-full mt-2 p-2 pr-6"
             :placeholder="$t('HACK.customization.titles.placeholder')"
             :aria-label="$t('HACK.customization.titles.subtitle')"
             type="text"
-            v-model="chartConfig.subtitle.text"
+            v-model="chartConfig.subtitle.text[activeLang]"
         />
     </div>
 </template>
@@ -32,6 +38,7 @@ import { useChartStore } from '../../stores/chartStore';
 
 const chartStore = useChartStore();
 const chartConfig = computed(() => chartStore.chartConfig);
+const activeLang = computed(() => chartStore.activeLang);
 </script>
 
 <style lang="scss"></style>

--- a/src/components/side-menu.vue
+++ b/src/components/side-menu.vue
@@ -26,8 +26,14 @@
                     fill="none"
                     stroke="#707070"
                 >
-                    <path class="transition-all duration-500 ease-in-out" :d="`m3.5 7h${sidemenuStore.expanded ? '17' : '8.5'}`" />
-                    <path class="transition-all duration-500 ease-in-out" :d="`m3.5 12h${sidemenuStore.expanded ? '17' : '8.5'}`" />
+                    <path
+                        class="transition-all duration-500 ease-in-out"
+                        :d="`m3.5 7h${sidemenuStore.expanded ? '17' : '8.5'}`"
+                    />
+                    <path
+                        class="transition-all duration-500 ease-in-out"
+                        :d="`m3.5 12h${sidemenuStore.expanded ? '17' : '8.5'}`"
+                    />
                     <path d="m3.5 17h17" />
                 </svg>
             </button>
@@ -334,7 +340,7 @@
                 class="absolute right-2 bottom-2"
                 href="https://www.youtube.com/watch?v=zzk0VQ0dVMU&feature=youtu.be"
                 target="_blank"
-                v-if="chartStore.chartConfig && chartStore.chartConfig.title?.text.toLowerCase() === 'breakfast'"
+                v-if="chartStore.chartConfig && chartStore.chartConfig.title?.text?.en.toLowerCase() === 'breakfast'"
             >
                 <svg width="24" height="24" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" fill="#000000">
                     <g id="SVGRepo_iconCarrier">
@@ -361,11 +367,16 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useDataStore } from '../stores/dataStore';
 import { useChartStore } from '../stores/chartStore';
 import { useSidemenuStore } from '../stores/sidemenuStore';
 import { saveAs } from 'file-saver';
 import { CurrentView } from '../definitions';
+import type { LangId } from '../definitions';
+import { buildContextMenuLabels } from '@/utils/contextMenu';
+
+import JSZip from 'jszip';
 
 const emit = defineEmits(['change-view']);
 
@@ -381,14 +392,15 @@ defineProps({
     }
 });
 
+const { t } = useI18n();
 const chartStore = useChartStore();
 const dataStore = useDataStore();
 const sidemenuStore = useSidemenuStore();
 const uploaded = computed(() => dataStore.uploaded);
 const btnDisabled = computed(() => {
-    const chartKeys = Object.keys(chartStore.chartConfig)
+    const chartKeys = Object.keys(chartStore.chartConfig);
     const onlyContextMenu = chartKeys.length === 1 && chartKeys[0] === 'lang';
-    return (!uploaded.value && (chartKeys.length === 0 ||  onlyContextMenu)) || dataStore.datatableView === false;
+    return (!uploaded.value && (chartKeys.length === 0 || onlyContextMenu)) || dataStore.datatableView === false;
 });
 
 const highchartsInput = ref<HTMLInputElement | null>(null);
@@ -420,12 +432,56 @@ const handleConfigFileUpload = (event: Event) => {
     dataStore.setDatatableView(true);
 };
 
-const exportHighchartsConfig = () => {
-    const filename = `${chartStore.chartConfig.title?.text.toLowerCase()}.json`;
-    // stringify + create blob for exported config
-    const json = JSON.stringify(chartStore.chartConfig, null, 2);
-    const blob = new Blob([json], { type: 'application/json' });
-    saveAs(blob, filename);
+const localizeConfig = (chartConfig: any, lang: string): any => {
+    if (Array.isArray(chartConfig)) {
+        return chartConfig.map((item) => localizeConfig(item, lang));
+    }
+
+    if (chartConfig && typeof chartConfig === 'object') {
+        // if it's a translation object
+        if ('en' in chartConfig || 'fr' in chartConfig) {
+            return chartConfig[lang] || '';
+        }
+
+        // otherwise recurse
+        const result = {};
+        for (const key in chartConfig) {
+            result[key] = localizeConfig(chartConfig[key], lang);
+        }
+        return result;
+    }
+
+    return chartConfig;
+};
+
+const exportHighchartsConfig = async () => {
+    // if bilingual charts is enabled, export both lang configs, otherwise just the uploaded/page file lang config
+    const langsToExport = chartStore.isBilingual ? ['en', 'fr'] : [chartStore.activeLang];
+    const files = langsToExport.map((lang) => {
+        // stringify + create blob for exported config
+        const localized = localizeConfig(chartStore.chartConfig, lang);
+
+        // override the context menu translations for this language
+        localized.lang = buildContextMenuLabels(t, lang as LangId);
+
+        const filename = `${localized.title?.text?.toLowerCase() || 'chart'}-${lang}.json`;
+        const json = JSON.stringify(localized, null, 2);
+
+        return { filename, json };
+    });
+
+    if (files.length === 1) {
+        // single file (no zip)
+        const blob = new Blob([files[0].json], { type: 'application/json' });
+        saveAs(blob, files[0].filename);
+    } else {
+        const zip = new JSZip();
+        files.forEach(({ filename, json }) => zip.file(filename, json));
+        const zipName = `${chartStore.chartConfig.title?.text[dataStore.uploadedFileLang].toLowerCase()}.zip`;
+
+        const content = await zip.generateAsync({ type: 'blob' });
+        saveAs(content, zipName);
+    }
 };
 </script>
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -4,24 +4,24 @@ export interface HighchartsConfig {
     };
     lang?: ExportMenuOptions;
     title: {
-        text: string;
+        text: LocalizedString;
     };
     credits?: {
         enabled: boolean;
     };
     subtitle: {
-        text: string;
+        text: LocalizedString;
     };
     yAxis: {
         title: {
-            text: string;
+            text: LocalizedString;
         };
     };
     xAxis: {
         title: {
-            text: string;
+            text: LocalizedString;
         };
-        categories: (number | string)[];
+        categories: (number | LocalizedString)[];
     };
     data?: {
         csv: string;
@@ -64,7 +64,7 @@ export interface ExportMenuOptions {
 }
 
 export interface SeriesData {
-    name: string;
+    name: LocalizedString;
     type: string;
     color?: string;
     colors?: string[];
@@ -82,3 +82,10 @@ export enum CurrentView {
     Template = 'template',
     Customization = 'customization'
 }
+
+export type LangId = 'en' | 'fr';
+
+export type LocalizedString = {
+    en: string;
+    fr: string;
+};

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -1,6 +1,10 @@
 key,enValue,enValid,frValue,frValid
 HACK.lang.en,English,1,Anglais,1
 HACK.lang.fr,French,1,Français,1
+HACK.lang.config.en,English Configuration,1,Configuration Anglaise,0
+HACK.lang.config.fr,French Configuration,1,Configuration Française,0
+HACK.lang.config.translate,⚠ Ensure you complete translations for the {lang} configuration,1,⚠ Assurez-vous de compléter les traductions pour la configuration {lang},0
+HACK.lang.config.dismiss,Dismiss,1,Rejeter,0
 HACK.saveChanges,Save Chart,1,Enregistrer le Graphique,1
 HACK.highcharts,Highcharts Accessible Configuration Kit,1,Trousse de Configuration Accessible Highcharts,1
 HACK.HACK,HACK,1,TCAH,1
@@ -23,6 +27,8 @@ HACK.data.description,"Upload your data to start creating a highchart. You may e
 HACK.data.drag,Drag and drop file here,1,Glissez et déposez le fichier ici,1
 HACK.data.filename,File name,1,Nom de fichier,1
 HACK.data.upload,Select file from device,1,Sélectionner un fichier sur l'appareil,1
+HACK.data.upload.lang,Select the language of your uploaded file:,1,Sélectionnez la langue de votre fichier téléchargé :,0
+HACK.data.upload.lang.description,This determines which column will be treated as the source language for editing. The other language will be pre-populated and marked for translation.,1,Cela détermine la colonne qui sera considérée comme la langue source pour la modification. L'autre langue sera préremplie et marquée pour la traduction.,0
 HACK.data.supported,"Supported file types: csv, xls, xlsx",1,"Types de fichiers pris en charge : csv, xls, xlsx",1
 HACK.data.unsupported,"Unsupported file type. Please upload a csv, xls, or xlsx file.",1,"Type de fichier non pris en charge. Veuillez télécharger un fichier csv, xls ou xlsx.",1
 HACK.data.import,Import data from file,1,Importer des données à partir d'un fichier,1

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import Highcharts from 'highcharts';
 import PatternFill from 'highcharts/modules/pattern-fill';
 import { ExportMenuOptions, HighchartsConfig, SeriesData } from '../definitions';
+import type { LangId, LocalizedString } from '../definitions';
 import type { PatternObject } from 'highcharts';
 
 PatternFill(Highcharts);
@@ -39,8 +40,28 @@ export const useChartStore = defineStore('chartProperties', {
             '#F7CAC9'
         ],
         usePatterns: true,
-        pieBaseColours: [] as string[]
+        pieBaseColours: [] as string[],
+        activeLang: 'en' as LangId,
+        isBilingual: true,
+        showLangWarning: true
     }),
+    getters: {
+        resolvedChartConfig(): HighchartsConfig {
+            const activeLang = this.activeLang;
+            const config = JSON.parse(JSON.stringify(this.chartConfig));
+
+            const resolve = (value: any): any => {
+                if (value === null || typeof value !== 'object') return value;
+                if ('en' in value && 'fr' in value) return value[activeLang];
+                const copy: any = Array.isArray(value) ? [] : {};
+                for (const key in value) {
+                    copy[key] = resolve(value[key]);
+                }
+                return copy;
+            };
+            return resolve(config);
+        }
+    },
 
     actions: {
         /** Reset store to initial state */
@@ -65,6 +86,11 @@ export const useChartStore = defineStore('chartProperties', {
                 '#88B04B',
                 '#F7CAC9'
             ];
+        },
+
+        /** Set active language */
+        setActiveLang(lang: LangId) {
+            this.activeLang = lang;
         },
 
         /** Set highcharts type */
@@ -99,18 +125,23 @@ export const useChartStore = defineStore('chartProperties', {
             this.chartConfig = {
                 ...chartConfig,
                 title: {
-                    text: chartConfig.title?.text || ''
+                    text: this.toBilingual(chartConfig.title?.text ?? '')
                 },
                 subtitle: {
-                    text: chartConfig.subtitle?.text || ''
+                    text: this.toBilingual(chartConfig.subtitle?.text ?? '')
                 },
                 xAxis: {
                     ...chartConfig.xAxis,
                     categories: Array.isArray(chartConfig.xAxis?.categories)
-                        ? chartConfig.xAxis.categories
-                        : new Array(chartConfig.series?.[0]?.data?.length || 0).fill(''),
+                        ? chartConfig.xAxis.categories.map((cat) =>
+                              typeof cat === 'string' ? { en: cat, fr: cat } : cat
+                          )
+                        : Array.from({ length: chartConfig.series?.[0]?.data?.length || 0 }, () => ({
+                              en: '',
+                              fr: ''
+                          })),
                     title: {
-                        text: chartConfig.xAxis?.title?.text || ''
+                        text: this.toBilingual(chartConfig.xAxis?.title?.text ?? '')
                     }
                 },
                 yAxis: Array.isArray(chartConfig.yAxis)
@@ -118,11 +149,12 @@ export const useChartStore = defineStore('chartProperties', {
                     : {
                           ...chartConfig.yAxis,
                           title: {
-                              text: chartConfig.yAxis?.title?.text || ''
+                              text: this.toBilingual(chartConfig.yAxis?.title?.text ?? '')
                           }
                       },
                 series: ((chartConfig.series as SeriesData[]) || []).map((series) => ({
                     ...series,
+                    name: this.toBilingual(series.name ?? ''),
                     type: series.type || '',
                     color: series.color || '',
                     dashStyle: series.dashStyle || '',
@@ -152,7 +184,7 @@ export const useChartStore = defineStore('chartProperties', {
                 const values = lines[i].split(';').map((val: string) => val.trim());
                 const seriesName = values[0];
                 seriesData.push({
-                    name: seriesName,
+                    name: this.toBilingual(seriesName),
                     data: values.slice(1).map((val: string) => parseInt(val)),
                     type: 'line',
                     color: this.defaultColours[i - 1],
@@ -165,9 +197,9 @@ export const useChartStore = defineStore('chartProperties', {
 
             // fill in extracted values (catos, x-axis title, series data) into chart config
             this.chartConfig.xAxis = {
-                categories: categories,
+                categories: categories.map((cat) => ({ en: String(cat), fr: String(cat) })),
                 title: {
-                    text: header[0] || ''
+                    text: { en: header[0] || '', fr: header[0] || '' }
                 }
             };
             this.chartConfig.series = seriesData;
@@ -175,27 +207,39 @@ export const useChartStore = defineStore('chartProperties', {
         },
 
         /** Set default highcharts config */
-        setupConfig(seriesNames: string[], cats: string[], seriesData: number[][], categoryLabel = ''): void {
+        setupConfig(
+            seriesNames: LocalizedString[],
+            cats: string[],
+            seriesData: number[][],
+            categoryLabel = { en: '', fr: '' }
+        ): void {
             this.chartConfig = {
                 title: {
-                    text: ''
+                    text: { en: '', fr: '' }
                 },
                 subtitle: {
-                    text: ''
+                    text: { en: '', fr: '' }
                 },
                 xAxis: {
-                    categories: cats,
+                    categories: cats.map((cat: any) =>
+                        typeof cat === 'string'
+                            ? { en: cat, fr: cat }
+                            : {
+                                  en: cat.en || '',
+                                  fr: cat.fr || ''
+                              }
+                    ),
                     title: {
                         text: categoryLabel
                     }
                 },
                 yAxis: {
                     title: {
-                        text: ''
+                        text: { en: '', fr: '' }
                     }
                 },
                 series: seriesNames.map((name, index) => ({
-                    name,
+                    name: name,
                     type: 'line',
                     color: this.defaultColours[index],
                     dashStyle: 'solid',
@@ -211,8 +255,8 @@ export const useChartStore = defineStore('chartProperties', {
         /** Update highcharts configuration for chart type */
         updateConfig(
             type: string,
-            series: string[],
-            headers: string[],
+            series: LocalizedString[],
+            headers: LocalizedString[],
             gridData: string[][],
             selectedSeries?: string,
             currentColours?: string[]
@@ -343,7 +387,7 @@ export const useChartStore = defineStore('chartProperties', {
         insertColumn(colIdx: number): void {
             const defaultData = new Array(this.chartConfig.xAxis.categories.length).fill(0);
             const newSeries: SeriesData = {
-                name: 'Untitled',
+                name: { en: 'Untitled', fr: 'Sans titre' },
                 type: this.chartType,
                 color: this.defaultColours[colIdx],
                 dashStyle: 'solid',
@@ -356,11 +400,17 @@ export const useChartStore = defineStore('chartProperties', {
         },
 
         /** Update header (series names) value */
-        updateHeader(colIdx: number, name: string): void {
+        updateHeader(colIdx: number, name: LocalizedString): void {
             if (colIdx === 0) {
                 this.chartConfig.xAxis.title.text = name;
-            } else {
-                (this.chartConfig.series as SeriesData[])[colIdx - 1].name = name;
+            } else if (Array.isArray(this.chartConfig.series)) {
+                const series = this.chartConfig.series[colIdx - 1];
+                if (!series) return;
+
+                if (typeof series.name === 'string') {
+                    series.name = { en: series.name, fr: series.name };
+                }
+                series.name[this.activeLang] = name[this.activeLang];
             }
         },
 
@@ -368,8 +418,17 @@ export const useChartStore = defineStore('chartProperties', {
         updateVal(rowIdx: number, colIdx: number, val: string): void {
             if (this.chartConfig.series[0].type === 'pie') {
                 if (colIdx === 0) {
-                    this.chartConfig.series[0].data[rowIdx].name = val;
-                    this.chartConfig.xAxis.categories[rowIdx] = val;
+                    const dataPoint = this.chartConfig.series[0].data[rowIdx];
+                    if (typeof dataPoint.name === 'string') {
+                        dataPoint.name = { en: dataPoint.name, fr: dataPoint.name };
+                    }
+                    dataPoint.name[this.activeLang] = val;
+
+                    const cat = this.chartConfig.xAxis.categories[rowIdx];
+                    if (typeof cat === 'string') {
+                        this.chartConfig.xAxis.categories[rowIdx] = { en: cat, fr: cat };
+                    }
+                    (this.chartConfig.xAxis.categories[rowIdx] as any)[this.activeLang] = val;
                 } else if (colIdx === 1) {
                     this.chartConfig.series[0].data[rowIdx].y = parseFloat(val);
                 }
@@ -377,15 +436,19 @@ export const useChartStore = defineStore('chartProperties', {
                 if (colIdx) {
                     this.chartConfig.series[colIdx - 1].data[rowIdx] = parseInt(val);
                 } else {
-                    this.chartConfig.xAxis.categories[rowIdx] = val;
+                    const cat = this.chartConfig.xAxis.categories[rowIdx];
+                    if (typeof cat === 'string') {
+                        this.chartConfig.xAxis.categories[rowIdx] = { en: cat, fr: cat };
+                    }
+                    (this.chartConfig.xAxis.categories[rowIdx] as any)[this.activeLang] = val;
                 }
             }
         },
 
         /** Update highcharts configuration for line chart */
-        updateLineChart(seriesNames: string[], seriesData: number[][]): void {
+        updateLineChart(seriesNames: LocalizedString[], seriesData: number[][]): void {
             this.chartConfig.series = this.chartConfig.series.map((series, index) =>
-                seriesNames.includes(series.name)
+                seriesNames.some((name) => name[this.activeLang] === series.name[this.activeLang])
                     ? {
                           name: series.name,
                           type: 'line',
@@ -400,9 +463,9 @@ export const useChartStore = defineStore('chartProperties', {
         },
 
         /** Update highcharts configuration for bar chart */
-        updateBarChart(seriesNames: string[], seriesData: number[][]): void {
+        updateBarChart(seriesNames: LocalizedString[], seriesData: number[][]): void {
             this.chartConfig.series = this.chartConfig.series.map((series, index) =>
-                seriesNames.includes(series.name)
+                seriesNames.some((name) => name[this.activeLang] === series.name[this.activeLang])
                     ? {
                           name: series.name,
                           type: 'bar',
@@ -419,9 +482,9 @@ export const useChartStore = defineStore('chartProperties', {
         },
 
         /** Update highcharts configuration for scatter plot */
-        updateScatterPlot(seriesNames: string[], seriesData: { x: number; y: number }[] | number[][]): void {
+        updateScatterPlot(seriesNames: LocalizedString[], seriesData: { x: number; y: number }[] | number[][]): void {
             this.chartConfig.series = this.chartConfig.series.map((series, index) =>
-                seriesNames.includes(series.name)
+                seriesNames.some((name) => name[this.activeLang] === series.name[this.activeLang])
                     ? {
                           name: series.name,
                           type: 'scatter',
@@ -445,9 +508,9 @@ export const useChartStore = defineStore('chartProperties', {
         },
 
         /** Update highcharts configuration for column chart */
-        updateColumnChart(seriesNames: string[], seriesData: number[][]): void {
+        updateColumnChart(seriesNames: LocalizedString[], seriesData: number[][]): void {
             this.chartConfig.series = this.chartConfig.series.map((series, index) =>
-                seriesNames.includes(series.name)
+                seriesNames.some((name) => name[this.activeLang] === series.name[this.activeLang])
                     ? {
                           name: series.name,
                           type: 'column',
@@ -464,9 +527,9 @@ export const useChartStore = defineStore('chartProperties', {
         },
 
         /** Update highcharts configuration for area chart */
-        updateAreaChart(seriesNames: string[], seriesData: number[][]): void {
+        updateAreaChart(seriesNames: LocalizedString[], seriesData: number[][]): void {
             this.chartConfig.series = this.chartConfig.series.map((series, index) =>
-                seriesNames.includes(series.name)
+                seriesNames.some((name) => name[this.activeLang] === series.name[this.activeLang])
                     ? {
                           name: series.name,
                           type: 'area',
@@ -481,9 +544,9 @@ export const useChartStore = defineStore('chartProperties', {
         },
 
         /** Update highcharts configuration for spline chart */
-        updateSplineChart(seriesNames: string[], seriesData: number[][]): void {
+        updateSplineChart(seriesNames: LocalizedString[], seriesData: number[][]): void {
             this.chartConfig.series = this.chartConfig.series.map((series, index) =>
-                seriesNames.includes(series.name)
+                seriesNames.some((name) => name[this.activeLang] === series.name[this.activeLang])
                     ? {
                           name: series.name,
                           type: 'spline',
@@ -499,7 +562,7 @@ export const useChartStore = defineStore('chartProperties', {
 
         /** Update highcharts configuration for pie chart */
         updatePieChart(
-            seriesNames: string[],
+            seriesNames: LocalizedString[],
             seriesIndex: number,
             seriesData: { name: string; y: number }[],
             currentColours?: string[]
@@ -594,8 +657,8 @@ export const useChartStore = defineStore('chartProperties', {
         updateHybridChart(hybridSeries: string[], hybridType: string): void {
             this.setHybridChartType(hybridType);
             this.chartConfig.series.forEach((series, index) => {
-                if (hybridSeries.includes(series.name)) {
-                    const isHybrid = hybridSeries.includes(series.name);
+                const isHybrid = hybridSeries.includes(series.name[this.activeLang]);
+                if (isHybrid) {
                     // TODO: may need to adjust based on what hybrid options become available in the future
                     const baseConfig = {
                         name: series.name,
@@ -611,12 +674,19 @@ export const useChartStore = defineStore('chartProperties', {
                 }
             });
         },
-        setSelectedHybridSeries(series: string[]) {
+        setSelectedHybridSeries(series: any) {
             this.selectedHybridSeries = series;
         },
 
         getSelectedHybridSeries() {
             return this.selectedHybridSeries;
+        },
+
+        toBilingual(value: string | { en?: string; fr?: string }): LocalizedString {
+            if (typeof value === 'string') {
+                return { en: value, fr: value };
+            }
+            return { en: value.en || '', fr: value.fr || '' };
         }
     }
 });

--- a/src/stores/dataStore.ts
+++ b/src/stores/dataStore.ts
@@ -1,14 +1,21 @@
 import { defineStore } from 'pinia';
 import { HighchartsConfig } from '@/definitions';
+import type { LangId, LocalizedString } from '@/definitions';
 
 export const useDataStore = defineStore('chartData', {
     state: () => ({
-        headers: [] as string[],
+        headers: [] as LocalizedString[],
         gridData: [] as string[][],
         uploaded: false,
-        datatableView: false
+        datatableView: false,
+        uploadedFileLang: 'en' as LangId
     }),
     actions: {
+        /** Set the uploaded file language */
+        setUploadedFileLang(lang: LangId) {
+            this.uploadedFileLang = lang;
+        },
+
         /** Reset store to initial state */
         resetStore(): void {
             this.headers = [];
@@ -18,7 +25,7 @@ export const useDataStore = defineStore('chartData', {
         },
 
         /** Initially set column headers */
-        setHeaders(headers: string[]): void {
+        setHeaders(headers: LocalizedString[]): void {
             this.headers = headers;
         },
 
@@ -40,7 +47,7 @@ export const useDataStore = defineStore('chartData', {
         // extract grid data from highcharts config file
         extractGridData(config: HighchartsConfig): void {
             if (config.series && Array.isArray(config.series)) {
-                const headers: string[] = config.series.map((series) => series.name);
+                const headers: LocalizedString[] = config.series.map((series) => series.name);
                 this.setHeaders(headers);
 
                 const gridData: string[][] = [];
@@ -62,7 +69,7 @@ export const useDataStore = defineStore('chartData', {
                         row.unshift(categories[idx] as string);
                     });
                     // add category header
-                    this.headers.unshift(config.xAxis.title?.text || '');
+                    this.headers.unshift(config.xAxis.title?.text || { en: '', fr: '' });
                 }
 
                 this.setGridData(gridData);
@@ -72,9 +79,13 @@ export const useDataStore = defineStore('chartData', {
         },
 
         /** Update cell value in grid data */
-        updateCell(row: number, col: number, value: string): void {
+        updateCell(row: number, col: number, value: string, lang: LangId): void {
             if (this.gridData[row]) {
-                this.gridData[row][col] = value;
+                if (col === 0) {
+                    this.gridData[row][col][lang] = value;
+                } else {
+                    this.gridData[row][col] = value;
+                }
             }
         },
 
@@ -116,7 +127,7 @@ export const useDataStore = defineStore('chartData', {
 
         /** Add new column to grid data */
         addNewCol(selectedColIdx: string, right: boolean = true): void {
-            const newCol = 'Untitled';
+            const newCol = { en: 'Untitled', fr: 'Sans titre' };
             // determine new position based on insert right/left
             const newIdx = right ? parseInt(selectedColIdx) + 1 : parseInt(selectedColIdx);
             // add new header and empty col of values

--- a/src/utils/contextMenu.ts
+++ b/src/utils/contextMenu.ts
@@ -1,0 +1,27 @@
+import type { LangId } from '@/definitions';
+
+// keys for the Highcharts context menu that need localization
+export const CONTEXT_MENU_KEYS = [
+    'viewFullscreen',
+    'printChart',
+    'downloadPNG',
+    'downloadJPEG',
+    'downloadPDF',
+    'downloadSVG',
+    'downloadCSV',
+    'downloadXLS',
+    'viewData'
+] as const;
+
+export type ContextMenuKey = (typeof CONTEXT_MENU_KEYS)[number];
+
+// Build a localized object of context menu labels for a given lanugage.
+export function buildContextMenuLabels(
+    t: (key: string, args?: any, options?: { locale?: LangId }) => string,
+    locale: LangId
+): Record<ContextMenuKey, string> {
+    return Object.fromEntries(CONTEXT_MENU_KEYS.map((key) => [key, t(`HACK.export.${key}`, {}, { locale })])) as Record<
+        ContextMenuKey,
+        string
+    >;
+}


### PR DESCRIPTION
### Related Item(s)
Issue #149 

### Changes
- Updated schema and definitions for translatable fields to use the shape:   `{  "en": { "type": "string" }, "fr": { "type": "string" }`. This is to ensure data consistency (fields that don’t need translation (e.g., series data) are identical across languages).
- Added language config tabs so to allow editing both Eng and Fr configs within the same UI
- Added `jszip` package to allow downloading/exporting both the English and French configs as a single zip folder
- Implemented a config resolver in `chartStore` so that chart preview displays the currently active lang

### Notes
- Currently I've implemented it as two tabs (EN/FR) to simplify editing series/category header names in the datatable, but  I'm open to alternative UI suggestions.
- Current implementation also pre-populates/copies fields from one language to the other instead of leaving them empty 

### Testing
Steps:
1. Upload new data or import an existing config
2. On `Data` page, notice the `English Configuration` and `French Configuration` tabs
3. Edit the header/category names for each language and verify that the chart preview changes accordingly
4. In `Customize Chart` page, notice the same language tabs for the `Chart titles` and `Axes` sections. 
5. Go to `Advanced` tab and confirm fields requiring translations now have separate `en` and `fr` fields 
6. Export the configuration and the zip contains two separate configs for `EN` and `FR`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/156)
<!-- Reviewable:end -->
