### PR TITLE
Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
             - name: Setup Node version
               uses: actions/setup-node@v3
               with:
-                  node-version: 22.0.0
+                  node-version: 24.14.0
 
             - name: Install and build
               run: |


### PR DESCRIPTION
### Related Item(s)

- Attempts to unruin #157

### Changes
- Updates github actions environment to run in Node 24

### Notes

It seems that since Hack builds demos on the team repo, it will not run the changes to the YML files until they get pulled.

### Testing

We wont actually know what this does until it gets merged, then another PR is opened, causing a demo to build using this change.

If it dies, can do a PR to revert this back to Node 22 (which will cause us problems eventually, given Github is going to migrate to N24 in a few months).

Will respect the personal risk tolerance of repo king Feng.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/158)
<!-- Reviewable:end -->
