### PR TITLE
Moved export config button to header in standalone

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -1,10 +1,10 @@
 <template>
     <div id="highcharts-editor-app" class="highcharts-app-container border border-gray-500">
         <header
-            class="editor-header h-[59px] top-0 flex border-b border-black bg-gray-200 py-2 px-2 justify-between z-40"
+            class="editor-header h-[59px] top-0 flex border-b border-black bg-gray-200 py-2 px-2 z-40"
             :class="{ sticky: !props.plugin }"
         >
-            <h1 class="w-mobile-full flex items-center truncate">
+            <h1 class="w-mobile-full flex items-center truncate pr-2.5">
                 <span class="font-semibold text-lg m-1" v-if="isMobile">
                     {{ $t('HACK.HACK') }}
                 </span>
@@ -13,34 +13,38 @@
                 </span>
             </h1>
 
-            <button
-                @click="changeLang"
-                class="bg-white border text-sm md:text-base rounded border-black hover:bg-gray-100 font-bold p-2 ml-auto mr-2"
-                v-if="!wetTemplate"
-            >
-                {{ appLang === 'en' ? $t('HACK.lang.fr') : $t('HACK.lang.en') }}
-            </button>
+            <div class="ml-auto flex items-center gap-1">
+                <!-- Export button added to header for standalone HACK so that it's more accessible -->
+                <ChartExport v-if="!props.plugin" :in-header="true" />
+                <button
+                    @click="changeLang"
+                    class="bg-white border text-sm md:text-base rounded border-black hover:bg-gray-100 font-bold p-2 ml-auto mr-2"
+                    v-if="!wetTemplate"
+                >
+                    {{ appLang === 'en' ? $t('HACK.lang.fr') : $t('HACK.lang.en') }}
+                </button>
 
-            <button
-                @click="emit('cancel')"
-                class="bg-white border text-sm md:text-base rounded border-black hover:bg-gray-100 font-bold p-2 ml-auto mr-2"
-                v-if="props.plugin"
-            >
-                {{ $t('HACK.label.cancel') }}
-            </button>
+                <button
+                    @click="emit('cancel')"
+                    class="bg-white border text-sm md:text-base rounded border-black hover:bg-gray-100 font-bold p-2 ml-auto mr-2"
+                    v-if="props.plugin"
+                >
+                    {{ $t('HACK.label.cancel') }}
+                </button>
 
-            <button
-                @click="saveChanges"
-                class="bg-black border rounded text-sm md:text-base border-black text-white hover:bg-gray-900 font-bold p-2"
-                :class="{ 'disabled hover:bg-gray-400': dataStore.datatableView === false }"
-                :disabled="dataStore.datatableView === false"
-                v-if="props.plugin"
-            >
-                {{ $t('HACK.saveChanges') }}
-                <span v-if="saving" class="align-middle inline-block px-1">
-                    <Spinner size="16px" color="#009cd1" class="ml-1 mb-1"></Spinner>
-                </span>
-            </button>
+                <button
+                    @click="saveChanges"
+                    class="bg-black border rounded text-sm md:text-base border-black text-white hover:bg-gray-900 font-bold p-2"
+                    :class="{ 'disabled hover:bg-gray-400': dataStore.datatableView === false }"
+                    :disabled="dataStore.datatableView === false"
+                    v-if="props.plugin"
+                >
+                    {{ $t('HACK.saveChanges') }}
+                    <span v-if="saving" class="align-middle inline-block px-1">
+                        <Spinner size="16px" color="#009cd1" class="ml-1 mb-1"></Spinner>
+                    </span>
+                </button>
+            </div>
         </header>
 
         <div class="items-stretch flex">
@@ -82,6 +86,7 @@ import Spinner from './components/helpers/spinner.vue';
 import DataSection from '@/components/data-section.vue';
 import ChartSelection from '@/components/chart-selection.vue';
 import ConfigCustomization from '@/components/config-customization.vue';
+import ChartExport from './components/helpers/chart-export.vue';
 const props = defineProps({
     plugin: {
         type: Boolean

--- a/src/components/helpers/chart-export.vue
+++ b/src/components/helpers/chart-export.vue
@@ -1,0 +1,135 @@
+<template>
+    <div :class="inHeader ? 'flex gap-1' : 'flex flex-col gap-2'">
+        <button
+            class="flex bg-white justify-center rounded border border-black hover:bg-gray-100 font-bold"
+            :class="[
+                btnDisabled && 'disabled hover:bg-gray-400',
+                inHeader
+                    ? 'items-center text-sm md:text-base leading-none max-w-60 p-2 pr-3 ml-auto mr-2'
+                    : 'w-full px-4 py-2'
+            ]"
+            :aria-label="$t('HACK.toc.exportConfig')"
+            :disabled="btnDisabled"
+            :tabIndex="btnDisabled ? -1 : 0"
+            @click="exportHighchartsConfig"
+        >
+            <svg
+                :class="['flex-shrink-0', inHeader ? 'w-5 h-5 md:w-6 sm:h-6' : 'w-6 h-6']"
+                xmlns="http://www.w3.org/2000/svg"
+                stroke="#000000"
+                viewBox="0 0 24 24"
+            >
+                <path d="M6 21H18M12 3V17M12 17L17 12M12 17L7 12" stroke-width="2" stroke-linecap="round"></path>
+            </svg>
+            {{ inHeader ? $t('HACK.export') : $t('HACK.toc.exportConfig') }}
+        </button>
+
+        <a
+            class="absolute right-2 bottom-2"
+            href="https://www.youtube.com/watch?v=zzk0VQ0dVMU&feature=youtu.be"
+            target="_blank"
+            v-if="chartStore.chartConfig && chartStore.chartConfig.title?.text?.en.toLowerCase() === 'breakfast'"
+        >
+            <svg width="24" height="24" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" fill="#000000">
+                <g id="SVGRepo_iconCarrier">
+                    <path
+                        fill="#F3F3F3"
+                        d="M67.283 96.847c-31.675 10.868-26.284-8.737-53.132-23.014-26.776-14.24-12.708-42.414 18.464-60.401 37.712-21.76 74.573-17.987 66.18 17.987-8.393 35.972-4.946 55.519-31.512 65.428z"
+                    ></path>
+                    <circle fill="#F0C419" cx="50" cy="47" r="19"></circle>
+                    <path
+                        stroke="#ffffff"
+                        stroke-width="4"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-miterlimit="10"
+                        d="M79 7.031c6.138 0 13.807 6.252 15.077 14.969M53 35.378c3.757 1.081 6.71 3.965 8.025 7.622"
+                        fill="none"
+                    ></path>
+                </g>
+            </svg>
+        </a>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useChartStore } from '@/stores/chartStore';
+import { useDataStore } from '@/stores/dataStore';
+
+import { saveAs } from 'file-saver';
+import type { LangId } from '@/definitions';
+import { buildContextMenuLabels } from '@/utils/contextMenu';
+
+import JSZip from 'jszip';
+
+defineProps({
+    inHeader: {
+        type: Boolean
+    }
+});
+
+const { locale, t } = useI18n();
+const chartStore = useChartStore();
+const dataStore = useDataStore();
+
+const uploaded = computed(() => dataStore.uploaded);
+const btnDisabled = computed(() => {
+    const chartKeys = Object.keys(chartStore.chartConfig);
+    const onlyContextMenu = chartKeys.length === 1 && chartKeys[0] === 'lang';
+    return (!uploaded.value && (chartKeys.length === 0 || onlyContextMenu)) || dataStore.datatableView === false;
+});
+
+const localizeConfig = (chartConfig: any, lang: string): any => {
+    if (Array.isArray(chartConfig)) {
+        return chartConfig.map((item) => localizeConfig(item, lang));
+    }
+
+    if (chartConfig && typeof chartConfig === 'object') {
+        // if it's a translation object
+        if ('en' in chartConfig || 'fr' in chartConfig) {
+            return chartConfig[lang] || '';
+        }
+
+        // otherwise recurse
+        const result = {};
+        for (const key in chartConfig) {
+            result[key] = localizeConfig(chartConfig[key], lang);
+        }
+        return result;
+    }
+
+    return chartConfig;
+};
+
+const exportHighchartsConfig = async () => {
+    // if bilingual charts is enabled, export both lang configs, otherwise just the uploaded/page file lang config
+    const langsToExport = chartStore.isBilingual ? ['en', 'fr'] : [chartStore.activeLang];
+    const files = langsToExport.map((lang) => {
+        // stringify + create blob for exported config
+        const localized = localizeConfig(chartStore.chartConfig, lang);
+
+        // override the context menu translations for this language
+        localized.lang = buildContextMenuLabels(t, lang as LangId);
+
+        const filename = `${localized.title?.text?.toLowerCase() || 'chart'}-${lang}.json`;
+        const json = JSON.stringify(localized, null, 2);
+
+        return { filename, json };
+    });
+
+    if (files.length === 1) {
+        // single file (no zip)
+        const blob = new Blob([files[0].json], { type: 'application/json' });
+        saveAs(blob, files[0].filename);
+    } else {
+        const zip = new JSZip();
+        files.forEach(({ filename, json }) => zip.file(filename, json));
+        const zipName = `${chartStore.chartConfig.title?.text[locale.value as LangId].toLowerCase()}.zip`;
+
+        const content = await zip.generateAsync({ type: 'blob' });
+        saveAs(content, zipName);
+    }
+};
+</script>

--- a/src/components/side-menu.vue
+++ b/src/components/side-menu.vue
@@ -283,6 +283,7 @@
         </ul>
 
         <div v-show="sidemenuStore.expanded">
+            <!-- Import button -->
             <button
                 class="flex bg-black text-white rounded justify-center border border-black w-full hover:bg-gray-900 font-bold px-4 py-2 my-2"
                 tabindex="0"
@@ -315,68 +316,20 @@
                 :aria-label="$t('HACK.toc.importChart')"
                 @change="handleConfigFileUpload"
             />
-            <button
-                class="flex bg-white justify-center rounded border border-black w-full hover:bg-gray-100 font-bold px-4 py-2 my-2"
-                :aria-label="$t('HACK.toc.exportConfig')"
-                :class="{ 'disabled hover:bg-gray-400': btnDisabled }"
-                :disabled="btnDisabled"
-                :tabIndex="btnDisabled ? -1 : 0"
-                @click="exportHighchartsConfig"
-            >
-                <svg
-                    class="flex-shrink-0"
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="24"
-                    height="24"
-                    stroke="#000000"
-                    viewBox="0 0 24 24"
-                >
-                    <path d="M6 21H18M12 3V17M12 17L17 12M12 17L7 12" stroke-width="2" stroke-linecap="round"></path>
-                </svg>
-                {{ $t('HACK.toc.exportConfig') }}
-            </button>
-
-            <a
-                class="absolute right-2 bottom-2"
-                href="https://www.youtube.com/watch?v=zzk0VQ0dVMU&feature=youtu.be"
-                target="_blank"
-                v-if="chartStore.chartConfig && chartStore.chartConfig.title?.text?.en.toLowerCase() === 'breakfast'"
-            >
-                <svg width="24" height="24" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" fill="#000000">
-                    <g id="SVGRepo_iconCarrier">
-                        <path
-                            fill="#F3F3F3"
-                            d="M67.283 96.847c-31.675 10.868-26.284-8.737-53.132-23.014-26.776-14.24-12.708-42.414 18.464-60.401 37.712-21.76 74.573-17.987 66.18 17.987-8.393 35.972-4.946 55.519-31.512 65.428z"
-                        ></path>
-                        <circle fill="#F0C419" cx="50" cy="47" r="19"></circle>
-                        <path
-                            stroke="#ffffff"
-                            stroke-width="4"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-miterlimit="10"
-                            d="M79 7.031c6.138 0 13.807 6.252 15.077 14.969M53 35.378c3.757 1.081 6.71 3.965 8.025 7.622"
-                            fill="none"
-                        ></path>
-                    </g>
-                </svg>
-            </a>
+            <!-- Export/download button -->
+            <ChartExport :in-header="false" />
         </div>
     </nav>
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { useI18n } from 'vue-i18n';
 import { useDataStore } from '../stores/dataStore';
 import { useChartStore } from '../stores/chartStore';
 import { useSidemenuStore } from '../stores/sidemenuStore';
-import { saveAs } from 'file-saver';
 import { CurrentView } from '../definitions';
-import type { LangId } from '../definitions';
-import { buildContextMenuLabels } from '@/utils/contextMenu';
 
-import JSZip from 'jszip';
+import ChartExport from './helpers/chart-export.vue';
 
 const emit = defineEmits(['change-view']);
 
@@ -392,7 +345,6 @@ defineProps({
     }
 });
 
-const { t } = useI18n();
 const chartStore = useChartStore();
 const dataStore = useDataStore();
 const sidemenuStore = useSidemenuStore();
@@ -430,58 +382,6 @@ const handleConfigFileUpload = (event: Event) => {
     // clear input
     (event.target as HTMLInputElement).value = '';
     dataStore.setDatatableView(true);
-};
-
-const localizeConfig = (chartConfig: any, lang: string): any => {
-    if (Array.isArray(chartConfig)) {
-        return chartConfig.map((item) => localizeConfig(item, lang));
-    }
-
-    if (chartConfig && typeof chartConfig === 'object') {
-        // if it's a translation object
-        if ('en' in chartConfig || 'fr' in chartConfig) {
-            return chartConfig[lang] || '';
-        }
-
-        // otherwise recurse
-        const result = {};
-        for (const key in chartConfig) {
-            result[key] = localizeConfig(chartConfig[key], lang);
-        }
-        return result;
-    }
-
-    return chartConfig;
-};
-
-const exportHighchartsConfig = async () => {
-    // if bilingual charts is enabled, export both lang configs, otherwise just the uploaded/page file lang config
-    const langsToExport = chartStore.isBilingual ? ['en', 'fr'] : [chartStore.activeLang];
-    const files = langsToExport.map((lang) => {
-        // stringify + create blob for exported config
-        const localized = localizeConfig(chartStore.chartConfig, lang);
-
-        // override the context menu translations for this language
-        localized.lang = buildContextMenuLabels(t, lang as LangId);
-
-        const filename = `${localized.title?.text?.toLowerCase() || 'chart'}-${lang}.json`;
-        const json = JSON.stringify(localized, null, 2);
-
-        return { filename, json };
-    });
-
-    if (files.length === 1) {
-        // single file (no zip)
-        const blob = new Blob([files[0].json], { type: 'application/json' });
-        saveAs(blob, files[0].filename);
-    } else {
-        const zip = new JSZip();
-        files.forEach(({ filename, json }) => zip.file(filename, json));
-        const zipName = `${chartStore.chartConfig.title?.text[dataStore.uploadedFileLang].toLowerCase()}.zip`;
-
-        const content = await zip.generateAsync({ type: 'blob' });
-        saveAs(content, zipName);
-    }
 };
 </script>
 

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -38,6 +38,7 @@ HACK.data.paste.label,Use pasted data,1,Utiliser des données collées,1
 HACK.data.paste.description,"Copy data from a CSV or Excel file, then paste in the box below. Please use comma separated values to best avoid errors. Note that the first row should correspond to axis/category titles.",1,"Copiez les données d'un fichier CSV ou Excel, puis collez-les dans le champ ci-dessous. Veuillez utiliser des valeurs séparées par des virgules pour éviter les erreurs. Notez que la premiÃ¨re ligne doit correspondre aux titres des axes/catégories.",1
 HACK.data.paste.placeholder,Paste data here,1,Collez les données ici,1
 HACK.data.modify,"Here, you can modify your dataset. The default standard is that the first column will be reserved for category labels.",1,"Ici, vous pouvez modifier votre ensemble de données. Par défaut, la première colonne est réservée aux libellés des catégories.",1
+HACK.export,Export,1,Exporter,0
 HACK.export.viewFullscreen,View in full screen,1,Plein Écran,1
 HACK.export.printChart,Print chart,1,Imprimer,1
 HACK.export.downloadPNG,Download PNG,1,Télécharger PNG,1


### PR DESCRIPTION
### Related Item(s)
Issue #155 

### Changes
- Extracted the export/download config button into a reusable component
- ~~Moved~~ Added button to top-right header in standalone mode (button remains in side menu ~~in plugin mode~~) 

### Testing
Steps:
1. Verify export/download config button appears in top-right header in standalone
2. Ensure export/download functionality remains unchanged

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/175)
<!-- Reviewable:end -->
