### PR TITLE
Ensure customizations persist when switching between chart types

### DIFF
--- a/src/components/chart-selection.vue
+++ b/src/components/chart-selection.vue
@@ -242,12 +242,16 @@ const handleChartSelection = (): void => {
     const seriesToUpdate = seriesNames.value.filter(
         (name) =>
             typeof name !== 'string' &&
-            !otherSeries.map((s) => (typeof s !== 'string' ? s[activeLang.value] : s)).includes(name[activeLang.value])
+            !otherSeries
+                .filter(Boolean)
+                .map((s) => (typeof s !== 'string' ? s[activeLang.value] : s))
+                .includes(name[activeLang.value])
     );
 
     if (chartType.value === 'pie') {
         hybridChartType.value = 'none';
         selectedHybridSeries.value = [];
+        chartStore.activeSeriesIndex = 0;
     }
 
     chartStore.updateConfig(chartType.value, seriesToUpdate, dataStore.headers, dataStore.gridData);

--- a/src/components/data-table.vue
+++ b/src/components/data-table.vue
@@ -459,6 +459,20 @@ const handleColAction = (): void => {
             dataStore.deleteCols(colIdxs);
             chartStore.deleteColumn(colIdxs);
             selectedCols.length = 0; // reset the selections
+
+            if (chartStore.chartType === 'pie') {
+                const activeSeries = chartStore.normalizedSeries[chartStore.activeSeriesIndex];
+                const data = activeSeries?.data;
+                const isPiePoint = Array.isArray(data) && data.length > 0 && typeof data[0] === 'object';
+
+                if (!activeSeries || !isPiePoint) {
+                    // active series has been deleted, need to update pie chart to display another series
+                    const seriesNames = Object.values(dataStore.headers).slice(1);
+                    chartStore.updateConfig('pie', seriesNames, dataStore.headers, dataStore.gridData);
+                } else {
+                    activeSeries.visible = true;
+                }
+            }
             break;
         }
         case colActions.insertRight: {

--- a/src/components/helpers/data-customization.vue
+++ b/src/components/helpers/data-customization.vue
@@ -281,11 +281,6 @@ const changeChartType = (updateChart = true) => {
         const selectedSeries = activeDataSeries.value;
         const seriesNames = Object.values(dataStore.headers).slice(1);
 
-        let currentColours: string[] = [];
-        if (activeSeries.value && 'name' in activeSeries.value && Array.isArray(activeSeries.value.colors)) {
-            currentColours = [...activeSeries.value.colors];
-        }
-
         const selectedSeriesName = Array.isArray(chartConfig.value.series)
             ? chartConfig.value.series[activeDataSeries.value]?.name
             : undefined;
@@ -295,8 +290,7 @@ const changeChartType = (updateChart = true) => {
             seriesNames,
             dataStore.headers,
             dataStore.gridData,
-            chartType.value === 'pie' ? selectedSeriesName : undefined,
-            currentColours
+            chartType.value === 'pie' ? selectedSeriesName : undefined
         );
         // set brief timeout to allow chart to re-render
         setTimeout(() => {

--- a/src/components/helpers/data-customization.vue
+++ b/src/components/helpers/data-customization.vue
@@ -5,7 +5,7 @@
         <div v-if="chartType != 'pie'" class="relative mt-2 selector">
             <select
                 class="border text-sm md:text-base border-black w-full p-2 rounded appearance-none cursor-pointer"
-                v-model="activeDataSeries"
+                v-model="chartStore.activeSeriesIndex"
                 :aria-label="$t('HACK.customization.dataSeries')"
                 @change="changeChartType(false)"
             >
@@ -202,10 +202,9 @@ watch(
 const chartConfig = computed(() => chartStore.chartConfig);
 const activeLang = computed(() => chartStore.activeLang);
 
-const activeDataSeries = ref<number>(0);
 const activeSeries = computed(() => {
     if (Array.isArray(chartStore.normalizedSeries)) {
-        return chartStore.normalizedSeries[activeDataSeries.value];
+        return chartStore.normalizedSeries[chartStore.activeSeriesIndex];
     } else {
         return chartStore.normalizedSeries;
     }
@@ -247,13 +246,13 @@ const markerOptions: Record<string, string> = {
 
 onBeforeMount(() => {
     const series = chartConfig.value.series;
-    activeDataSeries.value = 0;
+    chartStore.activeSeriesIndex = 0;
     chartType.value = activeSeries.value?.type ?? '';
     if (chartType.value === 'pie') {
         // To ensure that dropdown and colours reflect the graph being displayed when switching back to the data series tab
         if (Array.isArray(series)) {
             const visiblePieIndex = series.findIndex((s) => s.type === 'pie' && s.visible !== false);
-            activeDataSeries.value = visiblePieIndex !== -1 ? visiblePieIndex : 0;
+            chartStore.activeSeriesIndex = visiblePieIndex !== -1 ? visiblePieIndex : 0;
         }
         const activeSeriesColors = (activeSeries.value as SeriesData)?.colors;
         if (activeSeriesColors) {
@@ -278,26 +277,9 @@ const updatePieColour = (index: number, color: string) => {
 const changeChartType = (updateChart = true) => {
     if (updateChart || chartType.value === 'pie') {
         emit('loading', true);
-        const selectedSeries = activeDataSeries.value;
         const seriesNames = Object.values(dataStore.headers).slice(1);
 
-        let currentColours: string[] = [];
-        if (activeSeries.value && 'name' in activeSeries.value && Array.isArray(activeSeries.value.colors)) {
-            currentColours = [...activeSeries.value.colors];
-        }
-
-        const selectedSeriesName = Array.isArray(chartConfig.value.series)
-            ? chartConfig.value.series[activeDataSeries.value]?.name
-            : undefined;
-
-        chartStore.updateConfig(
-            chartType.value,
-            seriesNames,
-            dataStore.headers,
-            dataStore.gridData,
-            chartType.value === 'pie' ? selectedSeriesName : undefined,
-            currentColours
-        );
+        chartStore.updateConfig(chartType.value, seriesNames, dataStore.headers, dataStore.gridData);
         // set brief timeout to allow chart to re-render
         setTimeout(() => {
             emit('loading', false);

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -43,7 +43,8 @@ export const useChartStore = defineStore('chartProperties', {
         pieBaseColours: [] as string[],
         activeLang: 'en' as LangId,
         isBilingual: true,
-        showLangWarning: true
+        showLangWarning: true,
+        activeSeriesIndex: 0 as number
     }),
     getters: {
         resolvedChartConfig(): HighchartsConfig {
@@ -259,14 +260,7 @@ export const useChartStore = defineStore('chartProperties', {
         },
 
         /** Update highcharts configuration for chart type */
-        updateConfig(
-            type: string,
-            series: LocalizedString[],
-            headers: LocalizedString[],
-            gridData: GridRow[],
-            selectedSeries?: LocalizedString,
-            currentColours?: string[]
-        ): void {
+        updateConfig(type: string, series: LocalizedString[], headers: LocalizedString[], gridData: GridRow[]): void {
             this.chartConfig.tooltip = {};
             switch (type) {
                 case chartTemplates.area: {
@@ -335,17 +329,15 @@ export const useChartStore = defineStore('chartProperties', {
                 }
                 case chartTemplates.pie: {
                     this.setChartType('pie');
-                    const selectedSeriesIndex = headers.indexOf(selectedSeries || series[0]);
                     const data = gridData.map((row) => {
                         const [, ...values] = row;
                         return {
                             name: row[0],
-                            y: parseFloat(values[selectedSeriesIndex - 1])
+                            y: parseFloat(values[this.activeSeriesIndex])
                         };
                     });
-                    const colours = currentColours && currentColours.length > 0 ? currentColours : undefined;
                     const seriesNames = Object.values(headers).slice(1);
-                    this.updatePieChart(seriesNames, selectedSeriesIndex - 1, data, colours);
+                    this.updatePieChart(seriesNames, this.activeSeriesIndex, data);
                     break;
                 }
             }
@@ -370,12 +362,21 @@ export const useChartStore = defineStore('chartProperties', {
             sortedColIdxs.forEach((colIdx: number) => {
                 this.normalizedSeries.splice(colIdx - 1, 1);
             });
+
+            const isColDeleted = colIdxs.includes(this.activeSeriesIndex + 1);
+            if (this.chartType === 'pie' && isColDeleted) {
+                this.activeSeriesIndex = 0;
+            } else {
+                const shift = colIdxs.filter((i) => i < this.activeSeriesIndex + 1).length;
+                this.activeSeriesIndex -= shift;
+            }
         },
 
         /** Update data series after inserting row */
         insertRow(rowIdx: number): void {
             if (this.chartType === 'pie') {
-                const series = this.normalizedSeries[0];
+                const visiblePieIndex = this.normalizedSeries.findIndex((s) => s.visible !== false);
+                const series = this.normalizedSeries[visiblePieIndex];
                 const newColor = this.defaultColours[this.pieBaseColours.length % this.defaultColours.length];
 
                 if (!Array.isArray(series.data)) return;
@@ -399,6 +400,10 @@ export const useChartStore = defineStore('chartProperties', {
 
         /** Update data series after inserting column */
         insertColumn(colIdx: number): void {
+            // update active series index if it's inserted to the left of the active series
+            if (colIdx <= this.activeSeriesIndex + 1) {
+                this.activeSeriesIndex += 1;
+            }
             const defaultData = new Array(this.chartConfig.xAxis.categories.length).fill(0);
             const newSeries: SeriesData = {
                 name: { en: 'Untitled', fr: 'Sans titre' },
@@ -408,9 +413,15 @@ export const useChartStore = defineStore('chartProperties', {
                 marker: {
                     symbol: 'circle'
                 },
-                data: defaultData
+                data: defaultData,
+                visible: this.chartType === 'pie' ? false : true
             };
             (this.chartConfig.series as SeriesData[]).splice(colIdx - 1, 0, newSeries);
+
+            // restore visibility of current series for pie charts after shifting
+            if (this.chartType === 'pie' && this.normalizedSeries[this.activeSeriesIndex]) {
+                this.normalizedSeries[this.activeSeriesIndex].visible = true;
+            }
         },
 
         /** Update header (series names) value */
@@ -430,12 +441,13 @@ export const useChartStore = defineStore('chartProperties', {
 
         /** Update a single series value after data grid cell has been modified */
         updateVal(rowIdx: number, colIdx: number, val: string): void {
-            const series0 = this.normalizedSeries[0];
+            const visiblePieIndex = this.normalizedSeries.findIndex((s) => s.type === 'pie' && s.visible !== false);
+            const activeSeries = this.normalizedSeries[visiblePieIndex === -1 ? 0 : visiblePieIndex];
             const categories = this.chartConfig.xAxis.categories;
 
-            if (series0.type === 'pie' && Array.isArray(series0.data)) {
+            if (activeSeries.type === 'pie' && Array.isArray(activeSeries.data)) {
                 if (colIdx === 0) {
-                    const dataPoint = series0.data[rowIdx] as PiePoint;
+                    const dataPoint = activeSeries.data[rowIdx] as PiePoint;
                     if (typeof dataPoint.name === 'string') {
                         dataPoint.name = { en: dataPoint.name, fr: dataPoint.name };
                     }
@@ -446,8 +458,8 @@ export const useChartStore = defineStore('chartProperties', {
                         categories[rowIdx] = { en: cat, fr: cat };
                     }
                     (categories[rowIdx] as any)[this.activeLang] = val;
-                } else if (colIdx === 1) {
-                    (series0.data[rowIdx] as PiePoint).y = parseFloat(val);
+                } else if (colIdx === visiblePieIndex + 1) {
+                    (activeSeries.data[rowIdx] as PiePoint).y = parseFloat(val);
                 }
             } else {
                 if (colIdx) {
@@ -473,9 +485,9 @@ export const useChartStore = defineStore('chartProperties', {
                     ? {
                           name: series.name,
                           type: 'line',
-                          color: this.defaultColours[index],
-                          dashStyle: 'solid',
-                          marker: { symbol: 'circle' },
+                          color: series.color,
+                          dashStyle: series.dashStyle,
+                          marker: { symbol: series.marker?.symbol ?? 'circle' },
                           data: seriesData[index]
                       }
                     : series
@@ -490,11 +502,9 @@ export const useChartStore = defineStore('chartProperties', {
                     ? {
                           name: series.name,
                           type: 'bar',
-                          color: this.defaultColours[index],
-                          dashStyle: 'solid',
-                          marker: {
-                              symbol: 'circle'
-                          },
+                          color: series.color,
+                          dashStyle: series.dashStyle,
+                          marker: { symbol: series.marker?.symbol ?? 'circle' },
                           data: seriesData[index]
                       }
                     : series
@@ -509,9 +519,9 @@ export const useChartStore = defineStore('chartProperties', {
                     ? {
                           name: series.name,
                           type: 'scatter',
-                          color: this.defaultColours[index],
-                          dashStyle: 'solid',
-                          marker: { symbol: 'circle' },
+                          color: series.color,
+                          dashStyle: series.dashStyle,
+                          marker: { symbol: series.marker?.symbol ?? 'circle' },
                           data: seriesData[index]
                       }
                     : series
@@ -535,11 +545,9 @@ export const useChartStore = defineStore('chartProperties', {
                     ? {
                           name: series.name,
                           type: 'column',
-                          color: this.defaultColours[index],
-                          dashStyle: 'solid',
-                          marker: {
-                              symbol: 'circle'
-                          },
+                          color: series.color,
+                          dashStyle: series.dashStyle,
+                          marker: { symbol: series.marker?.symbol ?? 'circle' },
                           data: seriesData[index]
                       }
                     : series
@@ -554,9 +562,9 @@ export const useChartStore = defineStore('chartProperties', {
                     ? {
                           name: series.name,
                           type: 'area',
-                          color: this.defaultColours[index],
-                          dashStyle: 'solid',
-                          marker: { symbol: 'circle' },
+                          color: series.color,
+                          dashStyle: series.dashStyle,
+                          marker: { symbol: series.marker?.symbol ?? 'circle' },
                           data: seriesData[index]
                       }
                     : series
@@ -571,9 +579,9 @@ export const useChartStore = defineStore('chartProperties', {
                     ? {
                           name: series.name,
                           type: 'spline',
-                          color: this.defaultColours[index],
-                          dashStyle: 'solid',
-                          marker: { symbol: 'circle' },
+                          color: series.color,
+                          dashStyle: series.dashStyle,
+                          marker: { symbol: series.marker?.symbol ?? 'circle' },
                           data: seriesData[index]
                       }
                     : series
@@ -585,8 +593,7 @@ export const useChartStore = defineStore('chartProperties', {
         updatePieChart(
             seriesNames: LocalizedString[],
             seriesIndex: number,
-            seriesData: { name: LocalizedString; y: number }[],
-            currentColours?: string[]
+            seriesData: { name: LocalizedString; y: number }[]
         ): void {
             // following would support pie chart as part of hybrid charts
             // this.chartConfig.series = this.chartConfig.series.map((series, index) =>
@@ -599,7 +606,9 @@ export const useChartStore = defineStore('chartProperties', {
                         name: seriesNames[seriesIndex],
                         type: 'pie',
                         data: seriesData,
-                        colors: currentColours || this.defaultColours.slice(0, seriesData.length)
+                        color: series.color,
+                        dashStyle: series.dashStyle,
+                        marker: { symbol: series.marker?.symbol ?? 'circle' }
                     };
                 } else {
                     return {
@@ -610,9 +619,9 @@ export const useChartStore = defineStore('chartProperties', {
                     };
                 }
             });
-            const base = currentColours && currentColours.length > 0 ? currentColours : this.defaultColours;
+            const base = this.pieBaseColours?.length ? this.pieBaseColours : this.defaultColours;
 
-            this.pieBaseColours = Array.from({ length: seriesData.length }, (_, i) => base[i % base.length]);
+            this.pieBaseColours = seriesData.map((_, i) => base[i % base.length]);
             if (this.usePatterns) {
                 this.applyPatterns();
             }

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -264,8 +264,7 @@ export const useChartStore = defineStore('chartProperties', {
             series: LocalizedString[],
             headers: LocalizedString[],
             gridData: GridRow[],
-            selectedSeries?: LocalizedString,
-            currentColours?: string[]
+            selectedSeries?: LocalizedString
         ): void {
             this.chartConfig.tooltip = {};
             switch (type) {
@@ -343,9 +342,8 @@ export const useChartStore = defineStore('chartProperties', {
                             y: parseFloat(values[selectedSeriesIndex - 1])
                         };
                     });
-                    const colours = currentColours && currentColours.length > 0 ? currentColours : undefined;
                     const seriesNames = Object.values(headers).slice(1);
-                    this.updatePieChart(seriesNames, selectedSeriesIndex - 1, data, colours);
+                    this.updatePieChart(seriesNames, selectedSeriesIndex - 1, data);
                     break;
                 }
             }
@@ -375,7 +373,8 @@ export const useChartStore = defineStore('chartProperties', {
         /** Update data series after inserting row */
         insertRow(rowIdx: number): void {
             if (this.chartType === 'pie') {
-                const series = this.normalizedSeries[0];
+                const visiblePieIndex = this.normalizedSeries.findIndex((s) => s.visible !== false);
+                const series = this.normalizedSeries[visiblePieIndex];
                 const newColor = this.defaultColours[this.pieBaseColours.length % this.defaultColours.length];
 
                 if (!Array.isArray(series.data)) return;
@@ -408,7 +407,8 @@ export const useChartStore = defineStore('chartProperties', {
                 marker: {
                     symbol: 'circle'
                 },
-                data: defaultData
+                data: defaultData,
+                visible: this.chartType === 'pie' ? false : true
             };
             (this.chartConfig.series as SeriesData[]).splice(colIdx - 1, 0, newSeries);
         },
@@ -430,12 +430,13 @@ export const useChartStore = defineStore('chartProperties', {
 
         /** Update a single series value after data grid cell has been modified */
         updateVal(rowIdx: number, colIdx: number, val: string): void {
-            const series0 = this.normalizedSeries[0];
+            const visiblePieIndex = this.normalizedSeries.findIndex((s) => s.type === 'pie' && s.visible !== false);
+            const activeSeries = this.normalizedSeries[visiblePieIndex === -1 ? 0 : visiblePieIndex];
             const categories = this.chartConfig.xAxis.categories;
 
-            if (series0.type === 'pie' && Array.isArray(series0.data)) {
+            if (activeSeries.type === 'pie' && Array.isArray(activeSeries.data)) {
                 if (colIdx === 0) {
-                    const dataPoint = series0.data[rowIdx] as PiePoint;
+                    const dataPoint = activeSeries.data[rowIdx] as PiePoint;
                     if (typeof dataPoint.name === 'string') {
                         dataPoint.name = { en: dataPoint.name, fr: dataPoint.name };
                     }
@@ -446,8 +447,8 @@ export const useChartStore = defineStore('chartProperties', {
                         categories[rowIdx] = { en: cat, fr: cat };
                     }
                     (categories[rowIdx] as any)[this.activeLang] = val;
-                } else if (colIdx === 1) {
-                    (series0.data[rowIdx] as PiePoint).y = parseFloat(val);
+                } else if (colIdx === visiblePieIndex + 1) {
+                    (activeSeries.data[rowIdx] as PiePoint).y = parseFloat(val);
                 }
             } else {
                 if (colIdx) {
@@ -473,9 +474,9 @@ export const useChartStore = defineStore('chartProperties', {
                     ? {
                           name: series.name,
                           type: 'line',
-                          color: this.defaultColours[index],
-                          dashStyle: 'solid',
-                          marker: { symbol: 'circle' },
+                          color: series.color,
+                          dashStyle: series.dashStyle,
+                          marker: { symbol: series.marker?.symbol ?? 'circle' },
                           data: seriesData[index]
                       }
                     : series
@@ -490,11 +491,9 @@ export const useChartStore = defineStore('chartProperties', {
                     ? {
                           name: series.name,
                           type: 'bar',
-                          color: this.defaultColours[index],
-                          dashStyle: 'solid',
-                          marker: {
-                              symbol: 'circle'
-                          },
+                          color: series.color,
+                          dashStyle: series.dashStyle,
+                          marker: { symbol: series.marker?.symbol ?? 'circle' },
                           data: seriesData[index]
                       }
                     : series
@@ -509,9 +508,9 @@ export const useChartStore = defineStore('chartProperties', {
                     ? {
                           name: series.name,
                           type: 'scatter',
-                          color: this.defaultColours[index],
-                          dashStyle: 'solid',
-                          marker: { symbol: 'circle' },
+                          color: series.color,
+                          dashStyle: series.dashStyle,
+                          marker: { symbol: series.marker?.symbol ?? 'circle' },
                           data: seriesData[index]
                       }
                     : series
@@ -535,11 +534,9 @@ export const useChartStore = defineStore('chartProperties', {
                     ? {
                           name: series.name,
                           type: 'column',
-                          color: this.defaultColours[index],
-                          dashStyle: 'solid',
-                          marker: {
-                              symbol: 'circle'
-                          },
+                          color: series.color,
+                          dashStyle: series.dashStyle,
+                          marker: { symbol: series.marker?.symbol ?? 'circle' },
                           data: seriesData[index]
                       }
                     : series
@@ -554,9 +551,9 @@ export const useChartStore = defineStore('chartProperties', {
                     ? {
                           name: series.name,
                           type: 'area',
-                          color: this.defaultColours[index],
-                          dashStyle: 'solid',
-                          marker: { symbol: 'circle' },
+                          color: series.color,
+                          dashStyle: series.dashStyle,
+                          marker: { symbol: series.marker?.symbol ?? 'circle' },
                           data: seriesData[index]
                       }
                     : series
@@ -571,9 +568,9 @@ export const useChartStore = defineStore('chartProperties', {
                     ? {
                           name: series.name,
                           type: 'spline',
-                          color: this.defaultColours[index],
-                          dashStyle: 'solid',
-                          marker: { symbol: 'circle' },
+                          color: series.color,
+                          dashStyle: series.dashStyle,
+                          marker: { symbol: series.marker?.symbol ?? 'circle' },
                           data: seriesData[index]
                       }
                     : series
@@ -585,8 +582,7 @@ export const useChartStore = defineStore('chartProperties', {
         updatePieChart(
             seriesNames: LocalizedString[],
             seriesIndex: number,
-            seriesData: { name: LocalizedString; y: number }[],
-            currentColours?: string[]
+            seriesData: { name: LocalizedString; y: number }[]
         ): void {
             // following would support pie chart as part of hybrid charts
             // this.chartConfig.series = this.chartConfig.series.map((series, index) =>
@@ -599,7 +595,9 @@ export const useChartStore = defineStore('chartProperties', {
                         name: seriesNames[seriesIndex],
                         type: 'pie',
                         data: seriesData,
-                        colors: currentColours || this.defaultColours.slice(0, seriesData.length)
+                        color: series.color,
+                        dashStyle: series.dashStyle,
+                        marker: { symbol: series.marker?.symbol ?? 'circle' }
                     };
                 } else {
                     return {
@@ -610,9 +608,9 @@ export const useChartStore = defineStore('chartProperties', {
                     };
                 }
             });
-            const base = currentColours && currentColours.length > 0 ? currentColours : this.defaultColours;
+            const base = this.pieBaseColours?.length ? this.pieBaseColours : this.defaultColours;
 
-            this.pieBaseColours = Array.from({ length: seriesData.length }, (_, i) => base[i % base.length]);
+            this.pieBaseColours = seriesData.map((_, i) => base[i % base.length]);
             if (this.usePatterns) {
                 this.applyPatterns();
             }


### PR DESCRIPTION
### Related Item(s)
Issues #134 & #143

### Changes
- Preserve series customizations when switching between chart types. 
- Use `pieBaseColours` to keep track/maintain pie chart colour state. 
- Fix pie chart overlap when adding a new column

### Testing
Steps:
1. Go to `Customize Chart` tab
2. In the `Data series` section, update chart colours/styles 
3. Switch between chart types and confirm styling persists
4. Switch to pie chart
5. Return to the data table and add a column with values
6. Ensure no overlapping pie charts

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/184)
<!-- Reviewable:end -->
