### PR TITLE
Correctly translated context menu, Screenreader translations

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -120,7 +120,7 @@ const currentView = ref<CurrentView>(CurrentView.Data);
 const resolvedChartConfig = chartStore.resolvedChartConfig;
 const activeLang = computed(() => chartStore.activeLang);
 
-const contextMenuLabels = computed(() => buildContextMenuLabels(t, activeLang.value));
+const contextMenuLabels = computed(() => buildContextMenuLabels(t));
 
 const isMobile = ref(false);
 
@@ -157,9 +157,17 @@ if (!props.title) {
     });
 }
 
-watch(activeLang, () => {
-    // set context menu labels based on the current language
+watch(i18n.locale, () => {
+    //set context menu language in standalone mode
     chartStore.setMenuOptions(contextMenuLabels.value);
+    chartStore.syncHighchartsLang(t, i18n.locale.value as LangId);
+    chartStore.refreshKey += 1;
+});
+
+watch(activeLang, () => {
+    //set context menu language in plugin mode
+    chartStore.setMenuOptions(contextMenuLabels.value);
+    chartStore.syncHighchartsLang(t, activeLang.value);
     chartStore.refreshKey += 1;
 });
 
@@ -167,10 +175,13 @@ onMounted(() => {
     checkScreenSize();
     window.addEventListener('resize', checkScreenSize);
     appLang.value = i18n.locale.value as LangId;
-    // set locale only when standalone usage
+    //set locale only when standalone usage
     if (!props.plugin) {
         i18n.locale.value = appLang.value;
     }
+
+     chartStore.setMenuOptions(contextMenuLabels.value);
+     chartStore.syncHighchartsLang(t, appLang.value as LangId);
 
     // clear store state (required for shared store state for multi-instance charts)
     if (props.plugin) {

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -39,7 +39,9 @@ HACK.data.paste.description,"Copy data from a CSV or Excel file, then paste in t
 HACK.data.paste.placeholder,Paste data here,1,Collez les données ici,1
 HACK.data.modify,"Here, you can modify your dataset. The default standard is that the first column will be reserved for category labels.",1,"Ici, vous pouvez modifier votre ensemble de données. Par défaut, la première colonne est réservée aux libellés des catégories.",1
 HACK.export,Export,1,Exporter,0
+HACK.export.contextButtonTitle,Chart context menu,1,Tableau menu contextuel,0
 HACK.export.viewFullscreen,View in full screen,1,Plein Écran,1
+HACK.export.exitFullscreen,Exit full screen,1,Quitter le plein écran,0
 HACK.export.printChart,Print chart,1,Imprimer,1
 HACK.export.downloadPNG,Download PNG,1,Télécharger PNG,1
 HACK.export.downloadJPEG,Download JPEG,1,Télécharger JPEG,1
@@ -114,3 +116,9 @@ HACK.customization.data.triangle,Triangle,1,Triangle,1
 HACK.customization.axes.yaxis,Y-axis title,1,Titre de l'axe Y,1
 HACK.customization.axes.xaxis,X-axis title,1,Titre de l'axe X,1
 HACK.customization.axes.placeholder,Untitled axis,1,Axes sans titre,1
+HACK.accessibility.defaultChartTitle,Chart,1,Graphique,0
+HACK.accessibility.svgContainerLabel,Interactive chart,1,Graphique interactif,0
+HACK.accessibility.screenReaderSection.beforeRegionLabel,before test test testChart,1,Graphique,0
+HACK.accessibility.screenReaderSection.afterRegionLabel,End of interactive chart,1,Fin du graphique interactif,0
+HACK.accessibility.screenReaderSection.endOfChartMarker,End of chart,1,Fin du graphique,0
+HACK.accessibility.legend.legendLabel,Chart legend,1,Légende du graphique,0

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -4,8 +4,146 @@ import PatternFill from 'highcharts/modules/pattern-fill';
 import { ExportMenuOptions, HighchartsConfig, SeriesData } from '../definitions';
 import type { GridRow, LangId, LocalizedString, PiePoint } from '../definitions';
 import type { PatternObject } from 'highcharts';
+import exporting from 'highcharts/modules/exporting';
+import exportData from 'highcharts/modules/export-data';
+import accessibility from 'highcharts/modules/accessibility';
 
 PatternFill(Highcharts);
+exporting(Highcharts);
+exportData(Highcharts);
+accessibility(Highcharts);
+
+const raw: Record<string, Record<string, string>> = {
+    en: {
+        chartContainerLabel: 'Chart : {title}',
+        credits: 'Chart credits: {creditsStr}',
+
+        'series.summary.line':
+            '{series.name}, line {seriesNumber} of {chart.series.length} with {series.points.length} data {#eq series.points.length 1}point{else}points{/eq}.',
+
+        'series.summary.bar':
+            '{series.name}, bar series {seriesNumber} of {chart.series.length} with {series.points.length} {#eq series.points.length 1}bar{else}bars{/eq}.',
+
+        'series.summary.column':
+            '{series.name}, bar series {seriesNumber} of {chart.series.length} with {series.points.length} {#eq series.points.length 1}bar{else}bars{/eq}.',
+
+        'series.summary.pie':
+            '{series.name}, pie {seriesNumber} of {chart.series.length} with {series.points.length} {#eq series.points.length 1}slice{else}slices{/eq}.',
+
+        'series.summary.scatter':
+            '{series.name}, scatter plot {seriesNumber} of {chart.series.length} with {series.points.length} {#eq series.points.length 1}point{else}points{/eq}.',
+
+        'series.summary.spline':
+            '{series.name}, line {seriesNumber} of {chart.series.length} with {series.points.length} data {#eq series.points.length 1}point{else}points{/eq}.',
+
+        'series.summary.default':
+            '{series.name}, series {seriesNumber} of {chart.series.length} with {series.points.length} data {#eq series.points.length 1}point{else}points{/eq}.',
+
+        'axis.xAxisDescriptionSingular': 'The chart has one X axis.',
+
+        'axis.xAxisDescriptionPlural': 'The chart has {numAxes} X axes.',
+
+        'axis.yAxisDescriptionSingular': 'The chart has 1 Y axis.',
+
+        'axis.yAxisDescriptionPlural': 'The chart has {numAxes} Y axes.',
+
+        'legend.legendItem': 'Show {itemName}',
+        'legend.legendLabelNoTitle': 'Toggle series visibility, {chartTitle}',
+        'exporting.chartMenuLabel': 'chart menu',
+        'exporting.menuButtonLabel': 'View chart menu',
+        barMultiple: 'Bar chart with {numSeries} data series.',
+        barSingle: 'Bar chart with {numPoints} {#eq numPoints 1}bar{else}bars{/eq}.',
+        columnMultiple: 'Column chart with {numSeries} data series.',
+        columnSingle: 'Column chart with {numPoints} {#eq numPoints 1}bar{else}bars{/eq}.',
+        combinationChart: 'Combination chart with {numSeries} data series.',
+        defaultMultiple: 'Chart with {numSeries} data series.',
+        defaultSingle: 'Chart with {numPoints} data {#eq numPoints 1}point{else}points{/eq}.',
+        emptyChart: 'Empty chart',
+        lineMultiple: 'Line chart with {numSeries} lines.',
+        lineSingle: 'Line chart with {numPoints} data {#eq numPoints 1}point{else}points{/eq}.',
+        pieSingle: 'Pie chart with {numPoints} {#eq numPoints 1}slice{else}slices{/eq}.',
+        scatterMultiple: 'Scatter chart with {numSeries} data series.',
+        scatterSingle: 'Scatter chart with {numPoints} {#eq numPoints 1}point{else}points{/eq}.',
+        splineMultiple: 'Line chart with {numSeries} lines.',
+        splineSingle: 'Line chart with {numPoints} data {#eq numPoints 1}point{else}points{/eq}.',
+        'series.summary.lineCombination':
+            '{series.name}, series {seriesNumber} of {chart.series.length}. Line with {series.points.length} data {#eq series.points.length 1}point{else}points{/eq}.',
+
+        'series.summary.barCombination':
+            '{series.name}, series {seriesNumber} of {chart.series.length}. Bar series with {series.points.length} {#eq series.points.length 1}bar{else}bars{/eq}.',
+
+        'series.summary.columnCombination':
+            '{series.name}, series {seriesNumber} of {chart.series.length}. Column series with {series.points.length} {#eq series.points.length 1}bar{else}bars{/eq}.',
+
+        'series.summary.scatterCombination':
+            '{series.name}, series {seriesNumber} of {chart.series.length}. Scatter plot with {series.points.length} {#eq series.points.length 1}point{else}points{/eq}.',
+
+        'series.summary.splineCombination':
+            '{series.name}, series {seriesNumber} of {chart.series.length}. Line with {series.points.length} data {#eq series.points.length 1}point{else}points{/eq}.',
+
+        'series.summary.defaultCombination':
+            '{series.name}, series {seriesNumber} of {chart.series.length} with {series.points.length} data {#eq series.points.length 1}point{else}points{/eq}.'
+    },
+    fr: {
+        chartContainerLabel: 'Graphique : {title}',
+        credits: 'Crédits du graphique : {creditsStr}',
+        'series.summary.line':
+            '{series.name}, ligne {seriesNumber} sur {chart.series.length} avec {series.points.length} {#eq series.points.length 1}point{else}points{/eq}.',
+        'series.summary.bar':
+            '{series.name}, série en barres {seriesNumber} sur {chart.series.length} avec {series.points.length} {#eq series.points.length 1}barre{else}barres{/eq}.',
+        'series.summary.column':
+            '{series.name}, série en colonnes {seriesNumber} sur {chart.series.length} avec {series.points.length} {#eq series.points.length 1}colonne{else}colonnes{/eq}.',
+        'series.summary.pie':
+            '{series.name}, diagramme circulaire {seriesNumber} sur {chart.series.length} avec {series.points.length} {#eq series.points.length 1}part{else}parts{/eq}.',
+        'series.summary.scatter':
+            '{series.name}, nuage de points {seriesNumber} sur {chart.series.length} avec {series.points.length} {#eq series.points.length 1}point{else}points{/eq}.',
+        'series.summary.spline':
+            '{series.name}, courbe {seriesNumber} sur {chart.series.length} avec {series.points.length} {#eq series.points.length 1}point{else}points{/eq}.',
+        'series.summary.default':
+            '{series.name}, série {seriesNumber} sur {chart.series.length} avec {series.points.length} {#eq series.points.length 1}point{else}points{/eq}.',
+        'axis.xAxisDescriptionSingular': 'Le graphique comporte un axe X.',
+        'axis.xAxisDescriptionPlural': 'Le graphique comporte {numAxes} axes X.',
+        'axis.yAxisDescriptionSingular': 'Le graphique comporte un axe Y.',
+        'axis.yAxisDescriptionPlural': 'Le graphique comporte {numAxes} axes Y.',
+        'legend.legendItem': 'Afficher {itemName}',
+        'legend.legendLabelNoTitle': 'Afficher ou masquer la visibilité des séries, {chartTitle}.',
+        'exporting.chartMenuLabel': 'le menu du graphique',
+        'exporting.menuButtonLabel': 'Afficher le menu du graphique',
+        barMultiple: 'Graphique à barres avec {numSeries} séries de données.',
+        barSingle: 'Graphique à barres avec {numPoints} {#eq numPoints 1}barre{else}barres{/eq}.',
+        columnMultiple: 'Graphique en colonnes avec {numSeries} séries de données.',
+        columnSingle: 'Graphique en colonnes avec {numPoints} {#eq numPoints 1}colonne{else}colonnes{/eq}.',
+        combinationChart: 'Graphique combiné avec {numSeries} séries de données.',
+        defaultMultiple: 'Graphique avec {numSeries} séries de données.',
+        defaultSingle: 'Graphique avec {numPoints} données {#eq numPoints 1}point{else}points{/eq}.',
+        emptyChart: 'Graphique vide',
+        lineMultiple: 'Graphique en courbes avec {numSeries} lignes.',
+        lineSingle: 'Graphique en courbes avec {numPoints} données {#eq numPoints 1}point{else}points{/eq}.',
+        pieSingle: 'Graphique circulaire avec {numPoints} {#eq numPoints 1}part{else}parts{/eq}.',
+        scatterMultiple: 'Graphique de dispersion avec {numSeries} séries de données.',
+        scatterSingle: 'Graphique de dispersion avec {numPoints} {#eq numPoints 1}point{else}points{/eq}.',
+        splineMultiple: 'Graphique en courbes lissées avec {numSeries} lignes.',
+        splineSingle: 'Graphique en courbes lissées avec {numPoints} données {#eq numPoints 1}point{else}points{/eq}.',
+        'series.summary.lineCombination':
+            '{series.name}, série {seriesNumber} sur {chart.series.length}. Ligne avec {series.points.length} {#eq series.points.length 1}point{else}points{/eq}.',
+
+        'series.summary.barCombination':
+            '{series.name}, série {seriesNumber} sur {chart.series.length}. Série en barres avec {series.points.length} {#eq series.points.length 1}barre{else}barres{/eq}.',
+
+        'series.summary.columnCombination':
+            '{series.name}, série {seriesNumber} sur {chart.series.length}. Série en colonnes avec {series.points.length} {#eq series.points.length 1}colonne{else}colonnes{/eq}.',
+
+        'series.summary.scatterCombination':
+            '{series.name}, série {seriesNumber} sur {chart.series.length}. Nuage de points avec {series.points.length} {#eq series.points.length 1}point{else}points{/eq}.',
+
+        'series.summary.splineCombination':
+            '{series.name}, série {seriesNumber} sur {chart.series.length}. Courbe avec {series.points.length} {#eq series.points.length 1}point{else}points{/eq}.',
+
+        'series.summary.defaultCombination':
+            '{series.name}, série {seriesNumber} sur {chart.series.length} avec {series.points.length} {#eq series.points.length 1}point{else}points{/eq}.'
+    }
+};
+
 const chartTemplates: Record<string, string> = {
     area: 'area',
     bar: 'bar',
@@ -120,7 +258,78 @@ export const useChartStore = defineStore('chartProperties', {
 
         /** Set context/export menu strings */
         setMenuOptions(menuOptions: ExportMenuOptions): void {
-            this.chartConfig.lang = menuOptions;
+            Highcharts.setOptions({
+                lang: menuOptions,
+                accessibility: { enabled: true }
+            });
+        },
+
+        syncHighchartsLang(t: (key: string) => string, lang: LangId): void {
+            const r = raw[lang];
+            Highcharts.setOptions({
+                lang: {
+                    accessibility: {
+                        chartContainerLabel: r['chartContainerLabel'],
+                        defaultChartTitle: t('HACK.accessibility.defaultChartTitle'),
+                        svgContainerLabel: t('HACK.accessibility.svgContainerLabel'),
+                        credits: r['credits'],
+                        screenReaderSection: {
+                            beforeRegionLabel: t('HACK.accessibility.screenReaderSection.beforeRegionLabel'),
+                            afterRegionLabel: t('HACK.accessibility.screenReaderSection.afterRegionLabel'),
+                            endOfChartMarker: t('HACK.accessibility.screenReaderSection.endOfChartMarker')
+                        },
+                        series: {
+                            summary: {
+                                default: r['series.summary.default'],
+                                line: r['series.summary.line'],
+                                bar: r['series.summary.bar'],
+                                column: r['series.summary.column'],
+                                pie: r['series.summary.pie'],
+                                scatter: r['series.summary.scatter'],
+                                spline: r['series.summary.spline'],
+                                defaultCombination: r['series.summary.defaultCombination'],
+                                lineCombination: r['series.summary.lineCombination'],
+                                barCombination: r['series.summary.barCombination'],
+                                columnCombination: r['series.summary.columnCombination'],
+                                scatterCombination: r['series.summary.scatterCombination'],
+                                splineCombination: r['series.summary.splineCombination']
+                            }
+                        },
+                        exporting: {
+                            chartMenuLabel: r['exporting.chartMenuLabel'],
+                            menuButtonLabel: r['exporting.menuButtonLabel']
+                        },
+                        axis: {
+                            xAxisDescriptionSingular: r['axis.xAxisDescriptionSingular'],
+                            xAxisDescriptionPlural: r['axis.xAxisDescriptionPlural'],
+                            yAxisDescriptionSingular: r['axis.yAxisDescriptionSingular'],
+                            yAxisDescriptionPlural: r['axis.yAxisDescriptionPlural']
+                        },
+                        legend: {
+                            legendLabel: t('HACK.accessibility.legend.legendLabel'),
+                            legendItem: r['legend.legendItem'],
+                            legendLabelNoTitle: r['legend.legendLabelNoTitle']
+                        },
+                        chartTypes: {
+                            barMultiple: r['barMultiple'],
+                            barSingle: r['barSingle'],
+                            columnMultiple: r['columnMultiple'],
+                            columnSingle: r['columnSingle'],
+                            combinationChart: r['combinationChart'],
+                            defaultMultiple: r['defaultMultiple'],
+                            defaultSingle: r['defaultSingle'],
+                            emptyChart: r['emptyChart'],
+                            lineMultiple: r['lineMultiple'],
+                            lineSingle: r['lineSingle'],
+                            pieSingle: r['pieSingle'],
+                            scatterMultiple: r['scatterMultiple'],
+                            scatterSingle: r['scatterSingle'],
+                            splineMultiple: r['splineMultiple'],
+                            splineSingle: r['splineSingle']
+                        }
+                    }
+                }
+            });
         },
 
         /** Set highcharts config (from imported json file) */
@@ -129,6 +338,7 @@ export const useChartStore = defineStore('chartProperties', {
             // TODO: tons of edge cases here depending on the complexity of a chart configuration
             this.chartConfig = {
                 ...chartConfig,
+                accessibility: { enabled: true },
                 title: {
                     text: this.toBilingual(chartConfig.title?.text ?? '')
                 },
@@ -220,6 +430,7 @@ export const useChartStore = defineStore('chartProperties', {
             categoryLabel = { en: '', fr: '' }
         ): void {
             this.chartConfig = {
+                accessibility: { enabled: true },
                 title: {
                     text: { en: '', fr: '' }
                 },

--- a/src/utils/contextMenu.ts
+++ b/src/utils/contextMenu.ts
@@ -2,7 +2,9 @@ import type { LangId } from '@/definitions';
 
 // keys for the Highcharts context menu that need localization
 export const CONTEXT_MENU_KEYS = [
+    'contextButtonTitle',
     'viewFullscreen',
+    'exitFullscreen',
     'printChart',
     'downloadPNG',
     'downloadJPEG',
@@ -18,10 +20,12 @@ export type ContextMenuKey = (typeof CONTEXT_MENU_KEYS)[number];
 // Build a localized object of context menu labels for a given lanugage.
 export function buildContextMenuLabels(
     t: (key: string, args?: any, options?: { locale?: LangId }) => string,
-    locale: LangId
+    locale?: LangId
 ): Record<ContextMenuKey, string> {
-    return Object.fromEntries(CONTEXT_MENU_KEYS.map((key) => [key, t(`HACK.export.${key}`, {}, { locale })])) as Record<
-        ContextMenuKey,
-        string
-    >;
+    return Object.fromEntries(
+        CONTEXT_MENU_KEYS.map((key) => [
+            key,
+            locale ? t(`HACK.export.${key}`, {}, { locale }) : t(`HACK.export.${key}`)
+        ])
+    ) as Record<ContextMenuKey, string>;
 }


### PR DESCRIPTION
### Related Item(s)
Issue #162 

### Changes
- Context menu correctly translated to French on standalone
- Context menu view fullscreen and context menu tooltip correctly translated in plugin mode
- Added keyboard navigation for the chart
- Added screenreader support for the chart
- Added French screenreader translations for the chart

### Notes
- highcharts is not very compatible with narrator, I don't think there is any good way around it
- I tested this using NVDA as my screenreader
- the translations may have to be approved, most I added are also not in the typical lang.csv file
- I made translations based on the default highcharts screenreader text and some based off of CESI screenreader translations

### Testing
Steps:
1. Upload any chart file
2. Try to navigate the chart using keyboard
3. Enable a screenreader and try to navigate the chart
4. Change language to French
5. Ensure the context menu is correctly translated
6. Ensure screenreader is in French and reads French from the chart

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/185)
<!-- Reviewable:end -->
