### PR TITLE
Fix highcharts v12 module imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "file-saver": "^2.0.5",
-                "highcharts": "^11.4.8",
+                "highcharts": "^12.6.0",
                 "highcharts-vue": "^2.0.1",
                 "jsonschema": "^1.4.1",
                 "jszip": "^3.10.1",
@@ -3119,10 +3119,22 @@
             }
         },
         "node_modules/highcharts": {
-            "version": "11.4.8",
-            "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-11.4.8.tgz",
-            "integrity": "sha512-5Tke9LuzZszC4osaFisxLIcw7xgNGz4Sy3Jc9pRMV+ydm6sYqsPYdU8ELOgpzGNrbrRNDRBtveoR5xS3SzneEA==",
-            "license": "https://www.highcharts.com/license"
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-12.6.0.tgz",
+            "integrity": "sha512-zWwoXECOakJT2huBMqIZOjDNLLgyZFCcfZqTj2g6cvYOGxjF3nvooC+rIaF5aKiharluyGKNflfRNrzOAIjdRg==",
+            "license": "https://www.highcharts.com/license",
+            "peerDependencies": {
+                "jspdf": "^4.1.0",
+                "svg2pdf.js": "^2.7.0"
+            },
+            "peerDependenciesMeta": {
+                "jspdf": {
+                    "optional": true
+                },
+                "svg2pdf.js": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/highcharts-vue": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     ],
     "dependencies": {
         "file-saver": "^2.0.5",
-        "highcharts": "^11.4.8",
+        "highcharts": "^12.6.0",
         "highcharts-vue": "^2.0.1",
         "jsonschema": "^1.4.1",
         "jszip": "^3.10.1",

--- a/src/components/chart-selection.vue
+++ b/src/components/chart-selection.vue
@@ -133,14 +133,9 @@ import { useDataStore } from '../stores/dataStore';
 import { useSidemenuStore } from '../stores/sidemenuStore';
 import { CurrentView } from '../definitions';
 
-import Highcharts from 'highcharts';
-import dataModule from 'highcharts/modules/data';
-import exporting from 'highcharts/modules/exporting';
-import exportData from 'highcharts/modules/export-data';
-
-exporting(Highcharts);
-exportData(Highcharts);
-dataModule(Highcharts);
+import 'highcharts/modules/data';
+import 'highcharts/modules/exporting';
+import 'highcharts/modules/export-data';
 
 const emit = defineEmits(['change-view']);
 const props = defineProps({

--- a/src/components/config-customization.vue
+++ b/src/components/config-customization.vue
@@ -140,14 +140,9 @@ import AxesCustomization from './helpers/axes-customization.vue';
 
 import Ajv from 'ajv';
 
-import Highcharts from 'highcharts';
-import dataModule from 'highcharts/modules/data';
-import exporting from 'highcharts/modules/exporting';
-import exportData from 'highcharts/modules/export-data';
-
-exporting(Highcharts);
-exportData(Highcharts);
-dataModule(Highcharts);
+import 'highcharts/modules/data';
+import 'highcharts/modules/exporting';
+import 'highcharts/modules/export-data';
 
 const chartStore = useChartStore();
 const sidemenuStore = useSidemenuStore();

--- a/src/components/data-table.vue
+++ b/src/components/data-table.vue
@@ -207,16 +207,11 @@ import { useI18n } from 'vue-i18n';
 import { CurrentView } from '../definitions';
 import type { GridRow, LocalizedString, SeriesData } from '../definitions';
 
-import Highcharts from 'highcharts';
-import dataModule from 'highcharts/modules/data';
-import exporting from 'highcharts/modules/exporting';
-import exportData from 'highcharts/modules/export-data';
+import 'highcharts/modules/data';
+import 'highcharts/modules/exporting';
+import 'highcharts/modules/export-data';
 
 import LanguageTabs from './helpers/language-tabs.vue';
-
-exporting(Highcharts);
-exportData(Highcharts);
-dataModule(Highcharts);
 
 const { t } = useI18n();
 

--- a/src/stores/chartStore.ts
+++ b/src/stores/chartStore.ts
@@ -1,17 +1,12 @@
 import { defineStore } from 'pinia';
 import Highcharts from 'highcharts';
-import PatternFill from 'highcharts/modules/pattern-fill';
+import 'highcharts/modules/pattern-fill';
 import { ExportMenuOptions, HighchartsConfig, SeriesData } from '../definitions';
 import type { GridRow, LangId, LocalizedString, PiePoint } from '../definitions';
 import type { PatternObject } from 'highcharts';
-import exporting from 'highcharts/modules/exporting';
-import exportData from 'highcharts/modules/export-data';
-import accessibility from 'highcharts/modules/accessibility';
-
-PatternFill(Highcharts);
-exporting(Highcharts);
-exportData(Highcharts);
-accessibility(Highcharts);
+import 'highcharts/modules/exporting';
+import 'highcharts/modules/export-data';
+import 'highcharts/modules/accessibility';
 
 const raw: Record<string, Record<string, string>> = {
     en: {


### PR DESCRIPTION
### Related Item(s)
#194 

### Changes
- [FIX] Updated Highcharts module imports for compatibility with Highcharts v12.
- [FIX] Bumped `highcharts` from `11.4.8` to `12.6.0` in `package.json` and `package-lock.json`.

### Notes
Highcharts v12 no longer supports manually initializing modules with calls like `exporting(Highcharts)`. Module imports were updated to use side-effect imports instead, such as `import 'highcharts/modules/exporting';`.

### Testing
Steps:
1. Ran `npm run build` and confirmed the production app build completes successfully.
2. Ran `npm run build-plugin` and confirmed the plugin/library build completes successfully.
3. Ran `npm run dev` and manually tested the app with pasted CSV data.
4. Confirmed charts render correctly without Highcharts module initialization errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/195)
<!-- Reviewable:end -->
