### PR TITLE
Bump postcss to 8.5.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
                 "eslint": "^9.16.0",
                 "eslint-plugin-prettier": "^5.2.1",
                 "eslint-plugin-vue": "^9.32.0",
-                "postcss": "^8.4.47",
+                "postcss": "^8.5.12",
                 "prettier": "^3.3.3",
                 "tailwindcss": "^3.4.11",
                 "typescript": "^6.0.3",
@@ -4122,9 +4122,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
             "funding": [
                 {
                     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "eslint": "^9.16.0",
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-vue": "^9.32.0",
-        "postcss": "^8.4.47",
+        "postcss": "^8.5.12",
         "prettier": "^3.3.3",
         "tailwindcss": "^3.4.11",
         "typescript": "^6.0.3",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -9,6 +9,9 @@ export interface HighchartsConfig {
     credits?: {
         enabled: boolean;
     };
+    accessibility?: {
+        enabled: boolean;
+    };
     subtitle: {
         text: LocalizedString;
     };


### PR DESCRIPTION
### Related Item(s)
#183

### Changes
- [FIX] Bumped `postcss` from `8.5.8` to `8.5.12`.
- [FIX] Added the missing `accessibility` property to the local `HighchartsConfig` type.

### Notes
This resolves the postcss dependabot security bump manually from a regular branch. The original dependabot PR check failure looks like is caused by the GitHub workflow org member guard, not by a postcss build issue.

### Testing
Steps:
1. Ran `npm.cmd install postcss@8.5.12`.
2. Ran `npm.cmd run build` successfully.
3. Ran `npm.cmd run build-plugin` successfully.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/196)
<!-- Reviewable:end -->
