### PR TITLE
resets chart store when new file is uploaded

### DIFF
--- a/src/components/data-section.vue
+++ b/src/components/data-section.vue
@@ -237,6 +237,7 @@ onBeforeUnmount(() => {
 });
 
 const onFileUpload = (event: Event) => {
+    chartStore.resetStore();
     const uploadedFile = Array.from((event.target as HTMLInputElement).files as ArrayLike<File>)[0];
 
     if (uploadedFile && allowedTypes.includes(uploadedFile.type)) {


### PR DESCRIPTION
### Related Item(s)
Issue #198 
### Changes
- Resets chart store whenever a new file is uploaded, preventing old chart properties from carrying over

### Testing
Steps:
1. Upload a chart
2. Switch to bar chart (or any other chart)
3. Upload a new chart
4. Chart should be default state and not messed up

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/201)
<!-- Reviewable:end -->
