### PR TITLE
Fix Highcharts plugin on RESPECT

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -180,8 +180,8 @@ onMounted(() => {
         i18n.locale.value = appLang.value;
     }
 
-     chartStore.setMenuOptions(contextMenuLabels.value);
-     chartStore.syncHighchartsLang(t, appLang.value as LangId);
+    chartStore.setMenuOptions(contextMenuLabels.value);
+    chartStore.syncHighchartsLang(t, appLang.value as LangId);
 
     // clear store state (required for shared store state for multi-instance charts)
     if (props.plugin) {
@@ -224,7 +224,10 @@ const changeView = (view: CurrentView): void => {
 
 const saveChanges = (): void => {
     saving.value = true;
-    emit('saved', chartStore.chartConfig);
+
+    const configToEmit = chartStore.isBilingual ? chartStore.chartConfig : chartStore.resolvedChartConfig;
+    emit('saved', configToEmit);
+
     setTimeout(() => {
         saving.value = false;
     }, 1000);

--- a/src/components/config-customization.vue
+++ b/src/components/config-customization.vue
@@ -138,6 +138,11 @@ import TitlesCustomization from './helpers/titles-customization.vue';
 import DataCustomization from './helpers/data-customization.vue';
 import AxesCustomization from './helpers/axes-customization.vue';
 
+// @ts-ignore
+import { JsonEditor } from 'ramp-json-editor';
+// @ts-ignore
+import 'ramp-json-editor/dist/ramp-json-editor.css';
+
 import Ajv from 'ajv';
 
 import 'highcharts/modules/data';

--- a/src/components/data-section.vue
+++ b/src/components/data-section.vue
@@ -90,7 +90,7 @@
                 </div>
             </div>
 
-            <div v-if="fileName" class="mb-4 p-4 border rounded bg-gray-50">
+            <div v-if="fileName && chartStore.isBilingual" class="mb-4 p-4 border rounded bg-gray-50">
                 <div class="text-lg font-bold text-gray-700">
                     {{ $t('HACK.data.upload.lang') }}
                 </div>
@@ -168,7 +168,7 @@ import { useDataStore } from '../stores/dataStore';
 import { useChartStore } from '../stores/chartStore';
 import { useSidemenuStore } from '../stores/sidemenuStore';
 import { CurrentView } from '../definitions';
-import type { LangId } from '../definitions';
+import type { HighchartsConfig, LangId } from '../definitions';
 import { useI18n } from 'vue-i18n';
 
 import PasteData from './helpers/paste-data.vue';
@@ -237,7 +237,8 @@ onBeforeUnmount(() => {
 });
 
 const onFileUpload = (event: Event) => {
-    chartStore.resetStore();
+    chartStore.chartConfig = {} as HighchartsConfig;
+
     const uploadedFile = Array.from((event.target as HTMLInputElement).files as ArrayLike<File>)[0];
 
     if (uploadedFile && allowedTypes.includes(uploadedFile.type)) {

--- a/src/components/data-table.vue
+++ b/src/components/data-table.vue
@@ -87,7 +87,7 @@
                                     type="text"
                                     v-model="(headers[colIdx] as { [key: string]: string })[activeLang]"
                                     :aria-label="$t('HACK.datatable.colHeaders')"
-                                    :style="{ width: Math.max(header[activeLang].length + 2, 8) + 'ch' }"
+                                    :style="{ width: Math.max((header[activeLang] ?? header).length + 2, 8) + 'ch' }"
                                     :readonly="editingHeader !== colIdx"
                                     @input="updateHeader(colIdx, headers[colIdx])"
                                     @focus="editColHeader(colIdx)"


### PR DESCRIPTION
### Related Item(s)
Issue #187

### Changes
- [FIX] Emit `resolvedChartConfig` instead of `chartConfig` when saving non-bilingual charts
     - Resolves translatable fields (e.g., `{en, fr}`) to the active language for plugins with `bilingual` prop set to false

### Notes
- Currently, RESPECT uses the plugin in single-language mode, so the uploaded file language selector and the French configuration editing options should not be available.

### Testing
Steps:
1. Build the plugin into RESPECT
2. Add a new chart to the slide
3. Verify that all chart editing functionality works as expected
4. Click `Save Chart` and ensure all names and charts are properly displayed
5. Try editing the saved chart, and verify the configuration is loaded correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/highcharts-accessible-configuration-kit/210)
<!-- Reviewable:end -->
